### PR TITLE
Add service assignment fields

### DIFF
--- a/app/Http/Requests/StoreEventServiceRequest.php
+++ b/app/Http/Requests/StoreEventServiceRequest.php
@@ -14,6 +14,8 @@ class StoreEventServiceRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'service_type' => 'required|in:catering,photography,security',
+            'assigned_to' => 'required|exists:users,id',
             'catering_required' => 'required|boolean',
             'catering_people' => 'nullable|required_if:catering_required,true|integer|min:1',
             'dietary_requirements' => 'nullable|string',

--- a/app/Models/EventService.php
+++ b/app/Models/EventService.php
@@ -11,6 +11,8 @@ class EventService extends Model
 
     protected $fillable = [
         'event_id',
+        'service_type',
+        'assigned_to',
         'catering_required',
         'catering_people',
         'dietary_requirements',

--- a/app/Services/EventServiceDetailsService.php
+++ b/app/Services/EventServiceDetailsService.php
@@ -10,9 +10,11 @@ class EventServiceDetailsService
 {
     public function store(Event $event, StoreEventServiceRequest $request): EventService
     {
+        $data = $request->validated();
+
         return EventService::updateOrCreate(
-            ['event_id' => $event->id],
-            $request->validated()
+            ['event_id' => $event->id, 'service_type' => $data['service_type']],
+            $data
         );
     }
 

--- a/database/migrations/2025_06_08_084916_create_event_services_table.php
+++ b/database/migrations/2025_06_08_084916_create_event_services_table.php
@@ -16,6 +16,9 @@ return new class extends Migration
 
             $table->foreignId('event_id')->constrained()->onDelete('cascade');
 
+            $table->enum('service_type', ['catering', 'photography', 'security']);
+            $table->foreignId('assigned_to')->nullable()->constrained('users')->onDelete('cascade');
+
             // Catering
             $table->boolean('catering_required')->default(false);
             $table->unsignedInteger('catering_people')->nullable();

--- a/database/migrations/2025_07_20_000000_add_assignment_fields_to_event_services_table.php
+++ b/database/migrations/2025_07_20_000000_add_assignment_fields_to_event_services_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('event_services', function (Blueprint $table) {
+            if (!Schema::hasColumn('event_services', 'service_type')) {
+                $table->enum('service_type', ['catering', 'photography', 'security'])->after('event_id');
+            }
+            if (!Schema::hasColumn('event_services', 'assigned_to')) {
+                $table->foreignId('assigned_to')->nullable()->after('service_type')->constrained('users')->onDelete('cascade');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('event_services', function (Blueprint $table) {
+            if (Schema::hasColumn('event_services', 'assigned_to')) {
+                $table->dropForeign(['assigned_to']);
+                $table->dropColumn('assigned_to');
+            }
+            if (Schema::hasColumn('event_services', 'service_type')) {
+                $table->dropColumn('service_type');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add `service_type` and `assigned_to` columns to `event_services` table
- allow storing these fields
- add migration to retrofit existing databases

## Testing
- `php artisan migrate --pretend` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593636b0e48333b1aac55251a692c6