### PR TITLE
Add provider acceptance API

### DIFF
--- a/app/Http/Controllers/Api/Staff/EventServiceController.php
+++ b/app/Http/Controllers/Api/Staff/EventServiceController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Api\Staff;
 
 use App\Http\Controllers\Controller;
 use App\Services\EventServiceDetailsService;
+use App\Services\EventServiceStatusService;
+use App\Models\EventService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 
@@ -26,10 +28,12 @@ use Illuminate\Support\Facades\Auth;
 class EventServiceController extends Controller
 {
     protected EventServiceDetailsService $eventService;
+    protected EventServiceStatusService $statusService;
 
-    public function __construct(EventServiceDetailsService $eventService)
+    public function __construct(EventServiceDetailsService $eventService, EventServiceStatusService $statusService)
     {
         $this->eventService = $eventService;
+        $this->statusService = $statusService;
     }
 
     public function show(int $id): JsonResponse
@@ -43,5 +47,65 @@ class EventServiceController extends Controller
         }
 
         return response()->json(['data' => $service]);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/event-services/{id}/accept",
+     *     summary="Accept an assigned event service",
+     *     tags={"Staff - Assignments"},
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(response=200, description="Service accepted"),
+     *     @OA\Response(response=404, description="Not found or not assigned")
+     * )
+     */
+    public function accept(int $id): JsonResponse
+    {
+        $userId = Auth::id();
+        $service = EventService::where('id', $id)->where('assigned_to', $userId)->first();
+
+        if (!$service) {
+            return response()->json(['message' => 'Service not found or not assigned to you'], 404);
+        }
+
+        $updated = $this->statusService->accept($service);
+
+        return response()->json(['data' => $updated]);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/event-services/{id}/reject",
+     *     summary="Reject an assigned event service",
+     *     tags={"Staff - Assignments"},
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(response=200, description="Service rejected"),
+     *     @OA\Response(response=404, description="Not found or not assigned")
+     * )
+     */
+    public function reject(int $id): JsonResponse
+    {
+        $userId = Auth::id();
+        $service = EventService::where('id', $id)->where('assigned_to', $userId)->first();
+
+        if (!$service) {
+            return response()->json(['message' => 'Service not found or not assigned to you'], 404);
+        }
+
+        $updated = $this->statusService->reject($service);
+
+        return response()->json(['data' => $updated]);
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -35,7 +35,7 @@ class Event extends Model
 
     public function services()
     {
-        return $this->hasOne(EventService::class);
+        return $this->hasMany(EventService::class);
     }
 
     public function cancellationRequest()

--- a/app/Models/EventService.php
+++ b/app/Models/EventService.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\EventNote;
 
 class EventService extends Model
 {
@@ -23,10 +24,16 @@ class EventService extends Model
         'security_guards',
         'risk_assessment',
         'security_notes',
+        'status',
     ];
 
     public function event()
     {
         return $this->belongsTo(Event::class);
+    }
+
+    public function notes()
+    {
+        return $this->hasMany(EventNote::class);
     }
 }

--- a/app/Services/AdminBookingsService.php
+++ b/app/Services/AdminBookingsService.php
@@ -9,7 +9,7 @@ class AdminBookingsService
 {
     public function getFiltered(array $filters): Collection
     {
-        $query = Event::with('location', 'user');
+        $query = Event::with('location', 'user', 'services');
 
         if (!empty($filters['status'])) {
             $query->where('status', $filters['status']);

--- a/app/Services/AdminCalendarOverviewService.php
+++ b/app/Services/AdminCalendarOverviewService.php
@@ -10,7 +10,7 @@ class AdminCalendarOverviewService
 {
     public function getOverview(array $filters): Collection
     {
-        $query = Event::with('location', 'user');
+        $query = Event::with('location', 'user', 'services');
 
         if (!empty($filters['status'])) {
             $query->where('status', $filters['status']);

--- a/app/Services/AdminCalendarService.php
+++ b/app/Services/AdminCalendarService.php
@@ -10,7 +10,7 @@ class AdminCalendarService
 {
     public function getFilteredEvents(array $filters): Collection
     {
-        $query = Event::with('location', 'user');
+        $query = Event::with('location', 'user', 'services');
 
         if (!empty($filters['status'])) {
             $query->where('status', $filters['status']);

--- a/app/Services/AssignmentService.php
+++ b/app/Services/AssignmentService.php
@@ -23,6 +23,7 @@ class AssignmentService
                     'end_time' => $service->event->end_time,
                     'service_type' => $service->service_type,
                     'details' => $service->details,
+                    'status' => $service->status,
                 ];
             });
     }

--- a/app/Services/EventServiceStatusService.php
+++ b/app/Services/EventServiceStatusService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\EventService;
+
+class EventServiceStatusService
+{
+    public function accept(EventService $service): EventService
+    {
+        $service->status = 'accepted';
+        $service->save();
+
+        return $service;
+    }
+
+    public function reject(EventService $service): EventService
+    {
+        $service->status = 'rejected';
+        $service->save();
+
+        return $service;
+    }
+}

--- a/database/migrations/2025_07_21_000000_add_status_to_event_services_table.php
+++ b/database/migrations/2025_07_21_000000_add_status_to_event_services_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('event_services', function (Blueprint $table) {
+            if (!Schema::hasColumn('event_services', 'status')) {
+                $table->enum('status', ['pending','accepted','rejected'])->default('pending')->after('assigned_to');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('event_services', function (Blueprint $table) {
+            if (Schema::hasColumn('event_services', 'status')) {
+                $table->dropColumn('status');
+            }
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -68,4 +68,6 @@ Route::middleware(['auth:sanctum', 'role:catering|photography|security'])->group
     Route::get('/my-assignments', [MyAssignmentsController::class, 'index']);
     Route::post('/event-services/{id}/note', [EventNoteController::class, 'store']);
     Route::get('/event-services/{id}', [EventServiceController::class, 'show']);
+    Route::post('/event-services/{id}/accept', [EventServiceController::class, 'accept']);
+    Route::post('/event-services/{id}/reject', [EventServiceController::class, 'reject']);
 });


### PR DESCRIPTION
## Summary
- allow event services to track provider response via a new `status` field
- enable staff to accept or reject a service assignment
- surface service status on admin booking and calendar endpoints
- expose assignment status in staff listings
- document provider acceptance endpoints in Swagger

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593a93d358833399bec7da2d53bdd2