### PR TITLE
Fix inconsistent role naming

### DIFF
--- a/app/Http/Requests/AdminBookingsRequest.php
+++ b/app/Http/Requests/AdminBookingsRequest.php
@@ -8,7 +8,7 @@ class AdminBookingsRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()->hasRole('admin');
+        return $this->user()->hasAnyRole(['Admin', 'Super Admin']);
     }
 
     public function rules(): array

--- a/app/Http/Requests/FilterCalendarRequest.php
+++ b/app/Http/Requests/FilterCalendarRequest.php
@@ -8,7 +8,7 @@ class FilterCalendarRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()->hasRole('admin');
+        return $this->user()->hasAnyRole(['Admin', 'Super Admin']);
     }
 
     public function rules(): array

--- a/app/Http/Requests/HandleCancellationRequest.php
+++ b/app/Http/Requests/HandleCancellationRequest.php
@@ -8,7 +8,7 @@ class HandleCancellationRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()->hasRole('admin');
+        return $this->user()->hasAnyRole(['Admin', 'Super Admin']);
     }
 
     public function rules(): array

--- a/app/Http/Requests/PendingEventsRequest.php
+++ b/app/Http/Requests/PendingEventsRequest.php
@@ -8,7 +8,7 @@ class PendingEventsRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()->hasRole('admin');
+        return $this->user()->hasAnyRole(['Admin', 'Super Admin']);
     }
 
     public function rules(): array

--- a/app/Http/Requests/StoreEventNoteRequest.php
+++ b/app/Http/Requests/StoreEventNoteRequest.php
@@ -8,7 +8,7 @@ class StoreEventNoteRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()->hasAnyRole(['catering', 'photography', 'security']);
+        return $this->user()->hasAnyRole(['Catering', 'Photography', 'Security']);
     }
 
     public function rules(): array

--- a/app/Http/Requests/UpdateEventStatusRequest.php
+++ b/app/Http/Requests/UpdateEventStatusRequest.php
@@ -8,7 +8,7 @@ class UpdateEventStatusRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()->hasRole('admin');
+        return $this->user()->hasAnyRole(['Admin', 'Super Admin']);
     }
 
     public function rules(): array

--- a/app/Http/Requests/UpdateLocationRequest.php
+++ b/app/Http/Requests/UpdateLocationRequest.php
@@ -8,7 +8,7 @@ class UpdateLocationRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()?->hasRole('admin');
+        return $this->user()?->hasAnyRole(['Admin', 'Super Admin']);
     }
 
     public function rules(): array

--- a/app/Http/Requests/UpdateUserRoleRequest.php
+++ b/app/Http/Requests/UpdateUserRoleRequest.php
@@ -8,13 +8,13 @@ class UpdateUserRoleRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()->hasRole('admin');
+        return $this->user()->hasAnyRole(['Admin', 'Super Admin']);
     }
 
     public function rules(): array
     {
         return [
-            'role' => 'required|string|in:admin,general,catering,photography,security',
+            'role' => 'required|string|in:Admin,General,Catering,Photography,Security',
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,7 +64,7 @@ Route::middleware(['auth:sanctum', 'role:Admin'])->group(function () {
 });
 
 /////////Dashboard - Staff//////////////
-Route::middleware(['auth:sanctum', 'role:catering|photography|security'])->group(function () {
+Route::middleware(['auth:sanctum', 'role:Catering|Photography|Security'])->group(function () {
     Route::get('/my-assignments', [MyAssignmentsController::class, 'index']);
     Route::post('/event-services/{id}/note', [EventNoteController::class, 'store']);
     Route::get('/event-services/{id}', [EventServiceController::class, 'show']);


### PR DESCRIPTION
## Summary
- align role names across requests
- allow Super Admin in admin checks
- fix role validation values
- update route middleware role names

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6867d35a63588333a6078822a8ae2a92