### PR TITLE
Ensure event service assignments match staff roles

### DIFF
--- a/app/Http/Requests/StoreEventServiceRequest.php
+++ b/app/Http/Requests/StoreEventServiceRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use App\Rules\MatchesServiceRole;
 
 class StoreEventServiceRequest extends FormRequest
 {
@@ -13,13 +14,13 @@ class StoreEventServiceRequest extends FormRequest
 
     public function rules(?string $type = null): array
     {
+        $type = $type ?? $this->input('service_type');
+
         $rules = [
             'service_type' => 'required|in:catering,photography,security',
-            'assigned_to' => 'required|exists:users,id',
+            'assigned_to' => ['nullable', 'exists:users,id', new MatchesServiceRole($type)],
             'details' => 'required|array',
         ];
-
-        $type = $type ?? $this->input('service_type');
 
         if ($type === 'catering') {
             $rules['details.required'] = 'required|boolean';

--- a/app/Models/EventService.php
+++ b/app/Models/EventService.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\EventNote;
+use App\Models\User;
+use Illuminate\Validation\ValidationException;
 
 class EventService extends Model
 {
@@ -21,6 +23,29 @@ class EventService extends Model
     protected $casts = [
         'details' => 'array',
     ];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::saving(function (self $service) {
+            $roleName = ucfirst($service->service_type);
+
+            if ($service->assigned_to) {
+                $user = User::find($service->assigned_to);
+                if (!$user || !$user->hasRole($roleName)) {
+                    throw ValidationException::withMessages([
+                        'assigned_to' => ['Assigned user must have the ' . $roleName . ' role.'],
+                    ]);
+                }
+            } else {
+                $user = User::role($roleName)->first();
+                if ($user) {
+                    $service->assigned_to = $user->id;
+                }
+            }
+        });
+    }
 
     public function event()
     {

--- a/app/Rules/MatchesServiceRole.php
+++ b/app/Rules/MatchesServiceRole.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\User;
+use Illuminate\Contracts\Validation\Rule;
+
+class MatchesServiceRole implements Rule
+{
+    protected string $serviceType;
+
+    public function __construct(?string $serviceType)
+    {
+        $this->serviceType = $serviceType ? strtolower($serviceType) : '';
+    }
+
+    public function passes($attribute, $value): bool
+    {
+        if (!$value) {
+            return true; // handled elsewhere or default assignment
+        }
+
+        $user = User::find($value);
+        if (!$user) {
+            return false;
+        }
+
+        $role = ucfirst($this->serviceType);
+        return $user->hasRole($role);
+    }
+
+    public function message(): string
+    {
+        return 'The selected user does not have the appropriate role for this service.';
+    }
+}


### PR DESCRIPTION
## Summary
- check assigned users match service role
- default assignment to first matching role
- custom validation rule for service role

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869554c5dbc833387c952e9a309ee3b