### PR TITLE
Add locations API endpoint

### DIFF
--- a/app/Http/Controllers/Api/LocationController.php
+++ b/app/Http/Controllers/Api/LocationController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Location;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * @OA\Get(
+ *     path="/api/locations",
+ *     summary="List all locations",
+ *     @OA\Response(response=200, description="List of locations")
+ * )
+ */
+class LocationController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $locations = Location::select('id', 'name')->get();
+
+        return response()->json(['data' => $locations]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Api\CancellationController;
 use App\Http\Controllers\Api\EventServiceController;
 use App\Http\Controllers\Api\Staff\EventNoteController;
 use App\Http\Controllers\Api\Staff\MyAssignmentsController;
+use App\Http\Controllers\Api\LocationController;
 use Illuminate\Support\Facades\Route;
 
 
@@ -25,6 +26,9 @@ Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logo
 ////////////Microsoft Auth///////////////////////
 Route::get('/auth/microsoft', [MicrosoftAuthController::class, 'redirect']);
 Route::get('/auth/microsoft/callback', [MicrosoftAuthController::class, 'callback']);
+
+// Locations
+Route::get('/locations', [LocationController::class, 'index']);
 
 //////////Events////////////////
 Route::middleware('auth:sanctum')->group(function () {


### PR DESCRIPTION
## Summary
- create `LocationController` with index endpoint
- expose `GET /api/locations`

## Testing
- `php artisan test` *(fails: php: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab7c881b083338f9d3eeabdda3167