### PR TITLE
Send notification on service assignment

### DIFF
--- a/app/Models/EventService.php
+++ b/app/Models/EventService.php
@@ -56,4 +56,9 @@ class EventService extends Model
     {
         return $this->hasMany(EventNote::class);
     }
+
+    public function assignedUser()
+    {
+        return $this->belongsTo(User::class, 'assigned_to');
+    }
 }

--- a/app/Notifications/ServiceAssignedNotification.php
+++ b/app/Notifications/ServiceAssignedNotification.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\MailMessage;
+use App\Models\EventService;
+
+class ServiceAssignedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected EventService $service;
+
+    public function __construct(EventService $service)
+    {
+        $this->service = $service;
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $event = $this->service->event;
+
+        return (new MailMessage)
+            ->subject('New Service Assignment')
+            ->line('You have been assigned to a new service.')
+            ->line('Event: ' . $event->title)
+            ->line('Service Type: ' . ucfirst($this->service->service_type))
+            ->line('Start: ' . $event->start_time)
+            ->line('End: ' . $event->end_time);
+    }
+}

--- a/app/Services/EventServiceDetailsService.php
+++ b/app/Services/EventServiceDetailsService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Event;
 use App\Models\EventService;
 use App\Http\Requests\StoreEventServiceRequest;
+use App\Notifications\ServiceAssignedNotification;
 
 class EventServiceDetailsService
 {
@@ -12,10 +13,17 @@ class EventServiceDetailsService
     {
         $data = $request->validated();
 
-        return EventService::updateOrCreate(
+        $service = EventService::updateOrCreate(
             ['event_id' => $event->id, 'service_type' => $data['service_type']],
             $data
         );
+
+        $service->refresh();
+        if ($service->assignedUser) {
+            $service->assignedUser->notify(new ServiceAssignedNotification($service));
+        }
+
+        return $service;
     }
 
     public function getDetails(int $serviceId, int $userId): ?EventService


### PR DESCRIPTION
## Summary
- notify assigned users when a service is created or updated
- add `assignedUser` relationship to `EventService`
- implement `ServiceAssignedNotification`
- trigger the notification from event creation, update, and service store actions

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad710b110833395c70fec2cc36da9