### PR TITLE
Add event show endpoint with access checks

### DIFF
--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -147,4 +147,34 @@ class EventController extends Controller
             'data' => $bookings
         ]);
     }
+
+    /**
+     * @OA\Get(
+     *     path="/api/events/{id}",
+     *     summary="Get full details of an event",
+     *     tags={"Events"},
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="ID of the event",
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Response(response=200, description="Event details"),
+     *     @OA\Response(response=403, description="Not authorized")
+     * )
+     */
+    public function show(Request $request, Event $event): JsonResponse
+    {
+        $user = $request->user();
+
+        if ($event->user_id !== $user->id && !$user->hasAnyRole(['Super Admin', 'Admin'])) {
+            return response()->json(['error' => 'You are not authorized to view this event.'], 403);
+        }
+
+        $event->load('location', 'services');
+
+        return response()->json(['data' => $event]);
+    }
 }

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\Location;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class EventFactory extends Factory
+{
+    protected $model = Event::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'location_id' => Location::factory(),
+            'title' => $this->faker->sentence,
+            'details' => $this->faker->paragraph,
+            'expected_attendance' => $this->faker->numberBetween(10, 100),
+            'organizer_name' => $this->faker->name,
+            'organizer_email' => $this->faker->safeEmail,
+            'organizer_phone' => $this->faker->phoneNumber,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDays(2),
+            'status' => 'pending',
+        ];
+    }
+}
+

--- a/database/factories/LocationFactory.php
+++ b/database/factories/LocationFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Location;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LocationFactory extends Factory
+{
+    protected $model = Location::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->city,
+        ];
+    }
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,6 +33,7 @@ Route::get('/locations', [LocationController::class, 'index']);
 //////////Events////////////////
 Route::middleware('auth:sanctum')->group(function () {
     Route::post('/events', [EventController::class, 'store']);
+    Route::get('/events/{event}', [EventController::class, 'show']);
     Route::put('/events/{event}', [EventController::class, 'update']);
     Route::post('/events/{event}/cancel', [CancellationController::class, 'store']);
     Route::get('/my-bookings', [EventController::class, 'myBookings']);

--- a/tests/Feature/EventShowTest.php
+++ b/tests/Feature/EventShowTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\User;
+use Database\Seeders\RolesTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EventShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        $this->artisan('migrate');
+        $this->seed(RolesTableSeeder::class);
+    }
+
+    public function test_user_can_view_own_event(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $event = Event::factory()->for($user)->create();
+
+        $response = $this->actingAs($user)->getJson('/api/events/' . $event->id);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.id', $event->id);
+    }
+
+    public function test_admin_can_view_any_event(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('Admin');
+
+        $event = Event::factory()->create();
+
+        $response = $this->actingAs($admin)->getJson('/api/events/' . $event->id);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.id', $event->id);
+    }
+
+    public function test_user_cannot_view_others_event(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $otherUser = User::factory()->create();
+        $otherUser->assignRole('General');
+        $event = Event::factory()->for($otherUser)->create();
+
+        $response = $this->actingAs($user)->getJson('/api/events/' . $event->id);
+
+        $response->assertStatus(403);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `EventController@show` for retrieving event details
- expose new `/api/events/{event}` route
- add factories for `Event` and `Location`
- add feature tests for viewing events

## Testing
- `php artisan test --testsuite Feature` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b8f9df84083339a55c99503430f10