### PR TITLE
Fix CancellationRequest mass assignment

### DIFF
--- a/app/Models/CancellationRequest.php
+++ b/app/Models/CancellationRequest.php
@@ -8,4 +8,22 @@ use Illuminate\Database\Eloquent\Model;
 class CancellationRequest extends Model
 {
     use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'event_id',
+        'reason',
+        'details',
+        'status',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function event()
+    {
+        return $this->belongsTo(Event::class);
+    }
 }


### PR DESCRIPTION
## Summary
- allow mass assignment of CancellationRequest
- add relationships to user and event

## Testing
- `php -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686bbf87bea8833384cdf476bb58c6d7