### PR TITLE
Add roles listing endpoint

### DIFF
--- a/app/Http/Controllers/Api/Admin/AdminRoleController.php
+++ b/app/Http/Controllers/Api/Admin/AdminRoleController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Spatie\Permission\Models\Role;
+
+/**
+ * @OA\Get(
+ *     path="/api/admin/roles",
+ *     summary="List all roles",
+ *     tags={"Admin - Users"},
+ *     security={{"sanctum":{}}},
+ *     @OA\Response(response=200, description="List of roles")
+ * )
+ */
+class AdminRoleController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $roles = Role::select('id', 'name')->get();
+
+        return response()->json(['data' => $roles]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\Admin\AdminEventApprovalController;
 use App\Http\Controllers\Api\Admin\AdminLocationController;
 use App\Http\Controllers\Api\Admin\AdminPendingEventsController;
 use App\Http\Controllers\Api\Admin\AdminUserController;
+use App\Http\Controllers\Api\Admin\AdminRoleController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Auth\MicrosoftAuthController;
 use App\Http\Controllers\Api\EventController;
@@ -72,6 +73,7 @@ Route::middleware(['auth:sanctum', 'role:Admin'])->group(function () {
 
 Route::middleware(['auth:sanctum', 'role:Admin|Super Admin'])->group(function () {
     Route::put('/admin/users/{user}/role', [AdminUserController::class, 'updateRole']);
+    Route::get('/admin/roles', [AdminRoleController::class, 'index']);
 });
 
 Route::middleware(['auth:sanctum', 'role:Admin|Super Admin'])->prefix('admin/photography-types')->group(function () {

--- a/tests/Feature/FetchRolesTest.php
+++ b/tests/Feature/FetchRolesTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Database\Seeders\RolesTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Spatie\Permission\Models\Role;
+
+class FetchRolesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        $this->artisan('migrate');
+        $this->seed(RolesTableSeeder::class);
+    }
+
+    public function test_admin_can_fetch_roles(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('Admin');
+
+        $response = $this->actingAs($admin)->getJson('/api/admin/roles');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(Role::count(), 'data');
+    }
+}


### PR DESCRIPTION
## Summary
- create `AdminRoleController` to fetch roles
- expose `/api/admin/roles` route
- add feature test for new endpoint

## Testing
- `./vendor/bin/phpunit --filter FetchRolesTest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686cf4bff1bc83338c2e51f880d3a431