### PR TITLE
Use role id for user role updates

### DIFF
--- a/app/Http/Controllers/Api/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Api/Admin/AdminUserController.php
@@ -7,6 +7,7 @@ use App\Services\AdminUserService;
 use Illuminate\Http\JsonResponse;
 use App\Http\Requests\UpdateUserRoleRequest;
 use App\Models\User;
+use Spatie\Permission\Models\Role;
 
 
 /**
@@ -49,8 +50,8 @@ class AdminUserController extends Controller
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
-     *             required={"role"},
-     *             @OA\Property(property="role", type="string", example="catering")
+     *             required={"role_id"},
+     *             @OA\Property(property="role_id", type="integer", example=3)
      *         )
      *     ),
      *     @OA\Response(response=200, description="User role updated")
@@ -58,10 +59,11 @@ class AdminUserController extends Controller
      */
     public function updateRole(User $user, UpdateUserRoleRequest $request): JsonResponse
     {
-        $newRole = $request->validated('role');
+        $roleId = $request->validated('role_id');
+        $role = Role::findOrFail($roleId);
 
-        // remove old roles
-        $user->syncRoles([$newRole]);
+        // remove old roles and assign the new one
+        $user->syncRoles([$role->name]);
 
         return response()->json([
             'message' => 'User role updated successfully',

--- a/app/Http/Requests/UpdateUserRoleRequest.php
+++ b/app/Http/Requests/UpdateUserRoleRequest.php
@@ -14,7 +14,7 @@ class UpdateUserRoleRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'role' => 'required|string|in:Admin,General,Catering,Photography,Security',
+            'role_id' => 'required|integer|exists:roles,id',
         ];
     }
 }

--- a/tests/Feature/UpdateUserRoleTest.php
+++ b/tests/Feature/UpdateUserRoleTest.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Database\Seeders\RolesTableSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use Spatie\Permission\Models\Role;
 
 class UpdateUserRoleTest extends TestCase
 {
@@ -30,8 +31,10 @@ class UpdateUserRoleTest extends TestCase
         $user = User::factory()->create();
         $user->assignRole('General');
 
+        $roleId = Role::where('name', 'Catering')->first()->id;
+
         $response = $this->actingAs($admin)->putJson('/api/admin/users/' . $user->id . '/role', [
-            'role' => 'Catering',
+            'role_id' => $roleId,
         ]);
 
         $response->assertStatus(200);
@@ -46,8 +49,10 @@ class UpdateUserRoleTest extends TestCase
         $user = User::factory()->create();
         $user->assignRole('General');
 
+        $roleId = Role::where('name', 'Admin')->first()->id;
+
         $response = $this->actingAs($super)->putJson('/api/admin/users/' . $user->id . '/role', [
-            'role' => 'Admin',
+            'role_id' => $roleId,
         ]);
 
         $response->assertStatus(200);
@@ -62,8 +67,10 @@ class UpdateUserRoleTest extends TestCase
         $other = User::factory()->create();
         $other->assignRole('General');
 
+        $roleId = Role::where('name', 'Admin')->first()->id;
+
         $response = $this->actingAs($user)->putJson('/api/admin/users/' . $other->id . '/role', [
-            'role' => 'Admin',
+            'role_id' => $roleId,
         ]);
 
         $response->assertStatus(403);


### PR DESCRIPTION
## Summary
- allow updating user roles by specifying a `role_id` instead of role name
- fetch the role by id in `AdminUserController`
- adapt request validation and OpenAPI docs
- update related feature tests

## Testing
- `phpunit` *(fails: composer/phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d0102d3a0833385ae748ce21b7ead