### PR TITLE
Add booking modification restrictions

### DIFF
--- a/tests/Feature/EventModificationRestrictionTest.php
+++ b/tests/Feature/EventModificationRestrictionTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\User;
+use App\Models\Location;
+use Database\Seeders\RolesTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EventModificationRestrictionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        $this->artisan('migrate');
+        $this->seed(RolesTableSeeder::class);
+    }
+
+    public function test_user_cannot_update_event_within_two_weeks(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $location = Location::factory()->create();
+
+        $event = Event::factory()->for($user)->for($location)->create([
+            'start_time' => now()->addDays(10),
+            'end_time' => now()->addDays(11),
+            'status' => 'approved',
+        ]);
+
+        $response = $this->actingAs($user)->putJson('/api/events/' . $event->id, [
+            'title' => 'Updated',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_updating_approved_event_sets_status_to_pending(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $location = Location::factory()->create();
+
+        $event = Event::factory()->for($user)->for($location)->create([
+            'start_time' => now()->addDays(30),
+            'end_time' => now()->addDays(31),
+            'status' => 'approved',
+        ]);
+
+        $response = $this->actingAs($user)->putJson('/api/events/' . $event->id, [
+            'title' => 'Updated',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertEquals('pending', $event->fresh()->status);
+    }
+
+    public function test_user_cannot_cancel_event_within_two_weeks(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $location = Location::factory()->create();
+
+        $event = Event::factory()->for($user)->for($location)->create([
+            'start_time' => now()->addDays(10),
+            'end_time' => now()->addDays(11),
+            'status' => 'approved',
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/events/' . $event->id . '/cancel', [
+            'reason' => 'Change of plans',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_cancelling_event_creates_request_and_sets_pending(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $location = Location::factory()->create();
+
+        $event = Event::factory()->for($user)->for($location)->create([
+            'start_time' => now()->addDays(30),
+            'end_time' => now()->addDays(31),
+            'status' => 'approved',
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/events/' . $event->id . '/cancel', [
+            'reason' => 'Change of plans',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertEquals('pending', $event->fresh()->status);
+        $this->assertDatabaseHas('cancellation_requests', [
+            'event_id' => $event->id,
+            'user_id' => $user->id,
+            'reason' => 'Change of plans',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- block editing or cancelling events less than two weeks away
- revert approved events to pending when edited or cancellation is requested
- cover new restrictions with feature tests

## Testing
- `composer install` *(fails: unable to download packages)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687b44a09a3c8333b8839d18c91ca53e