### PR TITLE
Implement event lead time validation

### DIFF
--- a/app/Http/Requests/StoreEventRequest.php
+++ b/app/Http/Requests/StoreEventRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use App\Rules\LocationAvailable;
+use App\Rules\EventLeadTime;
 use App\Models\Event;
 
 class StoreEventRequest extends FormRequest
@@ -31,7 +32,12 @@ class StoreEventRequest extends FormRequest
             'organizer_email' => 'nullable|email|max:255',
             'organizer_phone' => 'nullable|string|max:20',
             'location_id' => 'required|exists:locations,id',
-            'start_time' => 'required|date|after_or_equal:now',
+            'start_time' => [
+                'required',
+                'date',
+                'after_or_equal:now',
+                new EventLeadTime($this->expected_attendance, $this->start_time),
+            ],
             'end_time' => [
                 'required',
                 'date',

--- a/app/Rules/EventLeadTime.php
+++ b/app/Rules/EventLeadTime.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Rules;
+
+use Carbon\Carbon;
+use Illuminate\Contracts\Validation\Rule;
+
+class EventLeadTime implements Rule
+{
+    protected ?int $expectedAttendance;
+    protected ?string $startTime;
+
+    public function __construct($expectedAttendance, $startTime)
+    {
+        $this->expectedAttendance = $expectedAttendance ? (int) $expectedAttendance : null;
+        $this->startTime = $startTime;
+    }
+
+    public function passes($attribute, $value): bool
+    {
+        if (!$this->startTime) {
+            return true;
+        }
+
+        $attendance = $this->expectedAttendance ?? 0;
+
+        if ($attendance <= 10) {
+            $minDays = 7;
+        } elseif ($attendance <= 30) {
+            $minDays = 14;
+        } elseif ($attendance <= 50) {
+            $minDays = 28;
+        } else {
+            $minDays = 42;
+        }
+
+        return Carbon::parse($this->startTime)->gte(Carbon::now()->addDays($minDays));
+    }
+
+    public function message(): string
+    {
+        return 'The event must be booked with more notice based on expected attendance.';
+    }
+}

--- a/tests/Feature/EventLeadTimeTest.php
+++ b/tests/Feature/EventLeadTimeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Location;
+use App\Models\User;
+use Database\Seeders\RolesTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EventLeadTimeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        $this->artisan('migrate');
+        $this->seed(RolesTableSeeder::class);
+    }
+
+    public function test_event_fails_without_required_lead_time(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $location = Location::factory()->create();
+
+        $response = $this->actingAs($user)->postJson('/api/events', [
+            'title' => 'Test Event',
+            'location_id' => $location->id,
+            'start_time' => now()->addWeeks(3)->toDateTimeString(),
+            'end_time' => now()->addWeeks(3)->addDay()->toDateTimeString(),
+            'expected_attendance' => 40,
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_event_succeeds_with_sufficient_lead_time(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $location = Location::factory()->create();
+
+        $response = $this->actingAs($user)->postJson('/api/events', [
+            'title' => 'Allowed Event',
+            'location_id' => $location->id,
+            'start_time' => now()->addWeeks(5)->toDateTimeString(),
+            'end_time' => now()->addWeeks(5)->addDay()->toDateTimeString(),
+            'expected_attendance' => 40,
+        ]);
+
+        $response->assertStatus(201);
+    }
+}


### PR DESCRIPTION
## Summary
- add `EventLeadTime` rule for enforcing minimum notice
- validate event start date with new rule
- cover lead time logic with feature tests

## Testing
- `php artisan test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b553a5b2883339d5fcea7bbba80d7