### PR TITLE
Add password management API

### DIFF
--- a/app/Http/Controllers/Api/PasswordController.php
+++ b/app/Http/Controllers/Api/PasswordController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdatePasswordRequest;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Http\JsonResponse;
+
+class PasswordController extends Controller
+{
+    /**
+     * @OA\Put(
+     *     path="/api/user/password",
+     *     summary="Set or change password",
+     *     tags={"Authentication"},
+     *     security={{"sanctum":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"password"},
+     *             @OA\Property(property="current_password", type="string"),
+     *             @OA\Property(property="password", type="string"),
+     *             @OA\Property(property="password_confirmation", type="string")
+     *         )
+     *     ),
+     *     @OA\Response(response=200, description="Password updated")
+     * )
+     */
+    public function update(UpdatePasswordRequest $request): JsonResponse
+    {
+        $user = $request->user();
+
+        if ($user->password) {
+            if (!Hash::check($request->input('current_password'), $user->password)) {
+                return response()->json(['error' => 'Current password is incorrect'], 422);
+            }
+        }
+
+        $user->password = Hash::make($request->password);
+        $user->save();
+
+        return response()->json(['message' => 'Password updated']);
+    }
+}

--- a/app/Http/Requests/UpdatePasswordRequest.php
+++ b/app/Http/Requests/UpdatePasswordRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePasswordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $rules = [
+            'password' => 'required|string|min:8|confirmed',
+        ];
+
+        if ($this->user()?->password) {
+            $rules['current_password'] = 'required|string';
+        }
+
+        return $rules;
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -37,4 +37,11 @@ class UserFactory extends Factory
             'email_verified_at' => null,
         ]);
     }
+
+    public function withoutPassword(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'password' => null,
+        ]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\Auth\MicrosoftAuthController;
 use App\Http\Controllers\Api\EventController;
 use App\Http\Controllers\Api\CancellationController;
 use App\Http\Controllers\Api\EventServiceController;
+use App\Http\Controllers\Api\PasswordController;
 use App\Http\Controllers\Api\Staff\EventNoteController;
 use App\Http\Controllers\Api\Staff\MyAssignmentsController;
 use App\Http\Controllers\Api\LocationController;
@@ -24,6 +25,7 @@ use Illuminate\Support\Facades\Route;
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
 Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
+Route::middleware('auth:sanctum')->put('/user/password', [PasswordController::class, 'update']);
 
 ////////////Microsoft Auth///////////////////////
 Route::get('/auth/microsoft', [MicrosoftAuthController::class, 'redirect']);

--- a/tests/Feature/PasswordUpdateTest.php
+++ b/tests/Feature/PasswordUpdateTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Database\Seeders\RolesTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class PasswordUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        $this->artisan('migrate');
+        $this->seed(RolesTableSeeder::class);
+    }
+
+    public function test_user_can_set_new_password_if_none_exists(): void
+    {
+        $user = User::factory()->withoutPassword()->create();
+        $user->assignRole('General');
+
+        $response = $this->actingAs($user)->putJson('/api/user/password', [
+            'password' => 'newsecret',
+            'password_confirmation' => 'newsecret',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertTrue(Hash::check('newsecret', $user->fresh()->password));
+    }
+
+    public function test_user_can_change_password_with_current_password(): void
+    {
+        $user = User::factory()->create(); // default password is 'password'
+        $user->assignRole('General');
+
+        $response = $this->actingAs($user)->putJson('/api/user/password', [
+            'current_password' => 'password',
+            'password' => 'changedpass',
+            'password_confirmation' => 'changedpass',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertTrue(Hash::check('changedpass', $user->fresh()->password));
+    }
+
+    public function test_change_fails_with_incorrect_current_password(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $response = $this->actingAs($user)->putJson('/api/user/password', [
+            'current_password' => 'wrongpass',
+            'password' => 'newpass',
+            'password_confirmation' => 'newpass',
+        ]);
+
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Summary
- allow changing or setting user password
- factory support for no-password state
- test password update scenarios

## Testing
- `composer install --ignore-platform-reqs` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687b6042fabc833387a712a39525c81d