### PR TITLE
Add filtering to my assignments

### DIFF
--- a/app/Http/Controllers/Api/Staff/MyAssignmentsController.php
+++ b/app/Http/Controllers/Api/Staff/MyAssignmentsController.php
@@ -4,15 +4,42 @@ namespace App\Http\Controllers\Api\Staff;
 
 use App\Http\Controllers\Controller;
 use App\Services\AssignmentService;
+use App\Http\Requests\FilterMyAssignmentsRequest;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 
 /**
  * @OA\Get(
  *     path="/api/my-assignments",
- *     summary="Get events assigned to the logged-in user",
+ *     summary="Get events assigned to the logged-in user with optional filters",
  *     tags={"Staff - Assignments"},
  *     security={{"sanctum":{}}},
+ *     @OA\Parameter(
+ *         name="status",
+ *         in="query",
+ *         required=false,
+ *         @OA\Schema(type="string", enum={"draft","pending","approved","rejected","cancelled"})
+ *     ),
+ *     @OA\Parameter(
+ *         name="location_id",
+ *         in="query",
+ *         required=false,
+ *         @OA\Schema(type="integer")
+ *     ),
+ *     @OA\Parameter(
+ *         name="date",
+ *         in="query",
+ *         required=false,
+ *         description="Format: YYYY-MM-DD",
+ *         @OA\Schema(type="string", example="2025-06-10")
+ *     ),
+ *     @OA\Parameter(
+ *         name="search",
+ *         in="query",
+ *         required=false,
+ *         description="Keyword to search in title or details",
+ *         @OA\Schema(type="string")
+ *     ),
  *     @OA\Response(response=200, description="List of assigned events")
  * )
  */
@@ -25,12 +52,12 @@ class MyAssignmentsController extends Controller
         $this->service = $service;
     }
 
-    public function index(): JsonResponse
+    public function index(FilterMyAssignmentsRequest $request): JsonResponse
     {
         $user = Auth::user();
         $role = $user->roles->pluck('name')->first(); // assuming one role per user
 
-        $events = $this->service->getMyAssignedEvents($user->id, $role);
+        $events = $this->service->getMyAssignedEvents($user->id, $role, $request->validated());
 
         return response()->json(['data' => $events]);
     }

--- a/app/Http/Requests/FilterMyAssignmentsRequest.php
+++ b/app/Http/Requests/FilterMyAssignmentsRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FilterMyAssignmentsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->hasAnyRole(['Catering', 'Photography', 'Security']);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'status' => 'nullable|in:pending,approved,rejected,cancelled,draft',
+            'location_id' => 'nullable|exists:locations,id',
+            'date' => 'nullable|date',
+            'search' => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/app/Services/AssignmentService.php
+++ b/app/Services/AssignmentService.php
@@ -7,24 +7,51 @@ use Illuminate\Support\Collection;
 
 class AssignmentService
 {
-    public function getMyAssignedEvents(int $userId, string $role): Collection
+    public function getMyAssignedEvents(int $userId, string $role, array $filters = []): Collection
     {
-        return EventService::with('event.location')
+        $query = EventService::with('event.location')
             ->where('service_type', $role)
-            ->where('assigned_to', $userId)
-            ->orderByDesc('created_at')
-            ->get()
-            ->map(function ($service) {
-                return [
-                    'event_id' => $service->event->id,
-                    'event_title' => $service->event->title,
-                    'location' => $service->event->location->name ?? null,
-                    'start_time' => $service->event->start_time,
-                    'end_time' => $service->event->end_time,
-                    'service_type' => $service->service_type,
-                    'details' => $service->details,
-                    'status' => $service->status,
-                ];
+            ->where('assigned_to', $userId);
+
+        if (!empty($filters['status'])) {
+            $query->whereHas('event', function ($q) use ($filters) {
+                $q->where('status', $filters['status']);
             });
+        }
+
+        if (!empty($filters['location_id'])) {
+            $query->whereHas('event', function ($q) use ($filters) {
+                $q->where('location_id', $filters['location_id']);
+            });
+        }
+
+        if (!empty($filters['date'])) {
+            $start = \Carbon\Carbon::parse($filters['date'])->startOfDay();
+            $end = $start->copy()->endOfDay();
+            $query->whereHas('event', function ($q) use ($start, $end) {
+                $q->whereBetween('start_time', [$start, $end]);
+            });
+        }
+
+        if (!empty($filters['search'])) {
+            $search = $filters['search'];
+            $query->whereHas('event', function ($q) use ($search) {
+                $q->where('title', 'like', "%{$search}%")
+                  ->orWhere('details', 'like', "%{$search}%");
+            });
+        }
+
+        return $query->orderByDesc('created_at')->get()->map(function ($service) {
+            return [
+                'event_id' => $service->event->id,
+                'event_title' => $service->event->title,
+                'location' => $service->event->location->name ?? null,
+                'start_time' => $service->event->start_time,
+                'end_time' => $service->event->end_time,
+                'service_type' => $service->service_type,
+                'details' => $service->details,
+                'status' => $service->status,
+            ];
+        });
     }
 }


### PR DESCRIPTION
## Summary
- allow staff to filter and search their assignments
- document new query parameters for `/api/my-assignments`

## Testing
- `php artisan test` *(fails: missing vendor)*

------
https://chatgpt.com/codex/tasks/task_e_687bbac1ee4c8333bcb2c6209b9689eb