### PR TITLE
Add search by name to admin users endpoint

### DIFF
--- a/app/Http/Controllers/Api/Admin/AdminUserController.php
+++ b/app/Http/Controllers/Api/Admin/AdminUserController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Services\AdminUserService;
 use Illuminate\Http\JsonResponse;
 use App\Http\Requests\UpdateUserRoleRequest;
+use App\Http\Requests\SearchUserRequest;
 use App\Models\User;
 use Spatie\Permission\Models\Role;
 
@@ -16,6 +17,13 @@ use Spatie\Permission\Models\Role;
  *     summary="List all users with their roles",
  *     tags={"Admin - Users"},
  *     security={{"sanctum":{}}},
+ *     @OA\Parameter(
+ *         name="search",
+ *         in="query",
+ *         required=false,
+ *         description="Search users by name",
+ *         @OA\Schema(type="string")
+ *     ),
  *     @OA\Response(response=200, description="Users list")
  * )
  */
@@ -28,9 +36,9 @@ class AdminUserController extends Controller
         $this->service = $service;
     }
 
-    public function index(): JsonResponse
+    public function index(SearchUserRequest $request): JsonResponse
     {
-        $users = $this->service->getAll();
+        $users = $this->service->getAll($request->validated());
 
         return response()->json(['data' => $users]);
     }

--- a/app/Http/Requests/SearchUserRequest.php
+++ b/app/Http/Requests/SearchUserRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->hasAnyRole(['Admin', 'Super Admin']);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'search' => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/app/Services/AdminUserService.php
+++ b/app/Services/AdminUserService.php
@@ -7,10 +7,17 @@ use Illuminate\Support\Collection;
 
 class AdminUserService
 {
-    public function getAll(): Collection
+    /**
+     * Retrieve all users with optional name search.
+     */
+    public function getAll(array $filters = []): Collection
     {
-        return User::with('roles')
-            ->orderBy('created_at', 'desc')
-            ->get();
+        $query = User::with('roles')->orderBy('created_at', 'desc');
+
+        if (!empty($filters['search'])) {
+            $query->where('name', 'like', '%' . $filters['search'] . '%');
+        }
+
+        return $query->get();
     }
 }


### PR DESCRIPTION
## Summary
- allow admins to search users by name
- document the new query parameter

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687c962be6208333a78e3bb0abfb8762