### PR TITLE
Add common filter keys across services

### DIFF
--- a/app/Http/Controllers/Api/Admin/AdminAllBookingsController.php
+++ b/app/Http/Controllers/Api/Admin/AdminAllBookingsController.php
@@ -18,6 +18,7 @@ use Illuminate\Http\JsonResponse;
  *     @OA\Parameter(name="start_date", in="query", @OA\Schema(type="string", format="date")),
  *     @OA\Parameter(name="organizer_email", in="query", @OA\Schema(type="string", format="email")),
  *     @OA\Parameter(name="title", in="query", @OA\Schema(type="string")),
+ *     @OA\Parameter(name="search", in="query", @OA\Schema(type="string")),
  *     @OA\Response(response=200, description="List of bookings")
  * )
  */

--- a/app/Http/Controllers/Api/Admin/AdminPendingEventsController.php
+++ b/app/Http/Controllers/Api/Admin/AdminPendingEventsController.php
@@ -37,6 +37,18 @@ use Illuminate\Http\JsonResponse;
  *         required=false,
  *         @OA\Schema(type="string", format="email")
  *     ),
+ *     @OA\Parameter(
+ *         name="status",
+ *         in="query",
+ *         required=false,
+ *         @OA\Schema(type="string", enum={"draft","pending","approved","rejected","cancelled"})
+ *     ),
+ *     @OA\Parameter(
+ *         name="search",
+ *         in="query",
+ *         required=false,
+ *         @OA\Schema(type="string")
+ *     ),
  *     @OA\Response(
  *         response=200,
  *         description="List of pending events"

--- a/app/Http/Requests/AdminBookingsRequest.php
+++ b/app/Http/Requests/AdminBookingsRequest.php
@@ -19,6 +19,7 @@ class AdminBookingsRequest extends FormRequest
             'start_date' => 'nullable|date',
             'organizer_email' => 'nullable|email',
             'title' => 'nullable|string|max:255',
+            'search' => 'nullable|string|max:255',
         ];
     }
 }

--- a/app/Http/Requests/PendingEventsRequest.php
+++ b/app/Http/Requests/PendingEventsRequest.php
@@ -18,6 +18,8 @@ class PendingEventsRequest extends FormRequest
             'start_date' => 'nullable|date',
             'title' => 'nullable|string|max:255',
             'organizer_email' => 'nullable|email',
+            'status' => 'nullable|in:pending,approved,rejected,cancelled,draft',
+            'search' => 'nullable|string|max:255',
         ];
     }
 }

--- a/app/Services/AdminBookingsService.php
+++ b/app/Services/AdminBookingsService.php
@@ -31,6 +31,14 @@ class AdminBookingsService
             $query->where('title', 'like', '%' . $filters['title'] . '%');
         }
 
+        if (!empty($filters['search'])) {
+            $search = $filters['search'];
+            $query->where(function ($q) use ($search) {
+                $q->where('title', 'like', "%{$search}%")
+                  ->orWhere('details', 'like', "%{$search}%");
+            });
+        }
+
         return $query->orderByDesc('created_at')->get();
     }
 }

--- a/app/Services/AdminPendingEventsService.php
+++ b/app/Services/AdminPendingEventsService.php
@@ -9,8 +9,13 @@ class AdminPendingEventsService
 {
     public function getFiltered(array $filters): Collection
     {
-        $query = Event::with('location', 'user')
-            ->where('status', 'pending');
+        $query = Event::with('location', 'user');
+
+        if (!empty($filters['status'])) {
+            $query->where('status', $filters['status']);
+        } else {
+            $query->where('status', 'pending');
+        }
 
         if (!empty($filters['location_id'])) {
             $query->where('location_id', $filters['location_id']);
@@ -26,6 +31,14 @@ class AdminPendingEventsService
 
         if (!empty($filters['organizer_email'])) {
             $query->where('organizer_email', $filters['organizer_email']);
+        }
+
+        if (!empty($filters['search'])) {
+            $search = $filters['search'];
+            $query->where(function ($q) use ($search) {
+                $q->where('title', 'like', "%{$search}%")
+                  ->orWhere('details', 'like', "%{$search}%");
+            });
         }
 
         return $query->orderBy('start_time')->get();


### PR DESCRIPTION
## Summary
- add `search` and `status` to requests for admin bookings and pending events
- support the new filter keys inside their respective services
- document the extra parameters in API controllers

## Testing
- `composer install --no-interaction` *(fails: PHP version mismatch)*
- `vendor/bin/phpunit -v` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687e0a7d0e248333a86bc497431ab787