### PR TITLE
Add availability API

### DIFF
--- a/app/Http/Controllers/Api/AvailabilityController.php
+++ b/app/Http/Controllers/Api/AvailabilityController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\CheckAvailabilityRequest;
+use App\Services\AvailabilityService;
+use Illuminate\Http\JsonResponse;
+
+class AvailabilityController extends Controller
+{
+    public function __construct(protected AvailabilityService $service) {}
+
+    public function index(CheckAvailabilityRequest $request): JsonResponse
+    {
+        $start = $request->input('start_time');
+        $end = $request->input('end_time');
+
+        return response()->json([
+            'data' => [
+                'locations' => $this->service->getAvailableLocations($start, $end),
+                'photography_available' => $this->service->photographyIsAvailable($start, $end),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/CheckAvailabilityRequest.php
+++ b/app/Http/Requests/CheckAvailabilityRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CheckAvailabilityRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'start_time' => 'required|date|after_or_equal:now',
+            'end_time' => 'required|date|after:start_time',
+        ];
+    }
+}

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -4,10 +4,16 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Event;
 
 class Location extends Model
 {
     use HasFactory;
 
     protected $fillable = ['name'];
+
+    public function events()
+    {
+        return $this->hasMany(Event::class);
+    }
 }

--- a/app/Services/AvailabilityService.php
+++ b/app/Services/AvailabilityService.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Location;
+use App\Models\EventService;
+
+class AvailabilityService
+{
+    public function getAvailableLocations(string $startTime, string $endTime)
+    {
+        return Location::whereDoesntHave('events', function ($query) use ($startTime, $endTime) {
+            $query->where('start_time', '<', $endTime)
+                  ->where('end_time', '>', $startTime);
+        })->select('id', 'name')->get();
+    }
+
+    public function photographyIsAvailable(string $startTime, string $endTime): bool
+    {
+        return !EventService::where('service_type', 'photography')
+            ->whereHas('event', function ($query) use ($startTime, $endTime) {
+                $query->where('start_time', '<', $endTime)
+                      ->where('end_time', '>', $startTime);
+            })
+            ->exists();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\Api\PasswordController;
 use App\Http\Controllers\Api\Staff\EventNoteController;
 use App\Http\Controllers\Api\Staff\MyAssignmentsController;
 use App\Http\Controllers\Api\LocationController;
+use App\Http\Controllers\Api\AvailabilityController;
 use App\Http\Controllers\Api\Admin\AdminPhotographyTypeController;
 use Illuminate\Support\Facades\Route;
 
@@ -34,6 +35,7 @@ Route::get('/auth/microsoft/callback', [MicrosoftAuthController::class, 'callbac
 // Locations
 Route::get('/locations', [LocationController::class, 'index']);
 Route::get('/photography-types', [\App\Http\Controllers\Api\PhotographyTypeController::class, 'index']);
+Route::get('/availability', [AvailabilityController::class, 'index']);
 
 //////////Events////////////////
 Route::middleware('auth:sanctum')->group(function () {

--- a/tests/Feature/AvailabilityTest.php
+++ b/tests/Feature/AvailabilityTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\EventService;
+use App\Models\Location;
+use App\Models\User;
+use Database\Seeders\RolesTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AvailabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        $this->artisan('migrate');
+        $this->seed(RolesTableSeeder::class);
+    }
+
+    public function test_it_returns_available_locations_and_photography_status(): void
+    {
+        $loc1 = Location::factory()->create();
+        $loc2 = Location::factory()->create();
+
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $photographer = User::factory()->create();
+        $photographer->assignRole('Photography');
+
+        $event = Event::factory()->for($user)->for($loc1)->create([
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDays(2),
+        ]);
+
+        EventService::create([
+            'event_id' => $event->id,
+            'service_type' => 'photography',
+            'assigned_to' => $photographer->id,
+            'details' => [],
+        ]);
+
+        $response = $this->getJson('/api/availability?start_time=' . now()->addDay()->toDateTimeString() . '&end_time=' . now()->addDays(2)->toDateTimeString());
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.photography_available', false);
+        $response->assertJsonCount(1, 'data.locations');
+        $response->assertEquals($loc2->id, $response->json('data.locations.0.id'));
+    }
+}


### PR DESCRIPTION
## Summary
- add `AvailabilityController` and route to fetch available locations
- add `CheckAvailabilityRequest` for validation
- implement `AvailabilityService`
- expose `events` relationship in `Location`
- create feature test for new API

## Testing
- `php artisan test --filter AvailabilityTest --testsuite Feature` *(fails: missing vendor)*

------
https://chatgpt.com/codex/tasks/task_e_6888fd2942588333a796037383448b14