### PR TITLE
Update photography and security request rules

### DIFF
--- a/app/Http/Requests/StoreEventServiceRequest.php
+++ b/app/Http/Requests/StoreEventServiceRequest.php
@@ -29,10 +29,11 @@ class StoreEventServiceRequest extends FormRequest
             $rules['details.notes'] = 'nullable|string';
         } elseif ($type === 'photography') {
             $rules['details.required'] = 'required|boolean';
-            $rules['details.photography_type_id'] = 'nullable|required_if:details.required,true|exists:photography_types,id';
+            $rules['details.photography_type_id'] = 'nullable|exists:photography_types,id';
+            $rules['details.notes'] = 'nullable|string';
         } elseif ($type === 'security') {
             $rules['details.required'] = 'required|boolean';
-            $rules['details.guards'] = 'nullable|required_if:details.required,true|integer|min:1';
+            $rules['details.guards'] = 'nullable|integer|min:1';
             $rules['details.risk_assessment'] = 'nullable|string';
             $rules['details.notes'] = 'nullable|string';
         }

--- a/tests/Feature/PhotographyTypeTest.php
+++ b/tests/Feature/PhotographyTypeTest.php
@@ -63,6 +63,31 @@ class PhotographyTypeTest extends TestCase
         $response->assertStatus(422);
     }
 
+    public function test_event_creation_allows_missing_photography_type_id(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $location = Location::factory()->create();
+
+        $response = $this->actingAs($user)->postJson('/api/events', [
+            'title' => 'Test',
+            'location_id' => $location->id,
+            'start_time' => now()->addDay()->toDateTimeString(),
+            'end_time' => now()->addDays(2)->toDateTimeString(),
+            'services' => [
+                [
+                    'service_type' => 'photography',
+                    'details' => [
+                        'required' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(201);
+    }
+
     public function test_can_fetch_photography_types(): void
     {
         PhotographyType::factory()->count(3)->create();

--- a/tests/Feature/SecurityServiceTest.php
+++ b/tests/Feature/SecurityServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Location;
+use Database\Seeders\RolesTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SecurityServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        $this->artisan('migrate');
+        $this->seed(RolesTableSeeder::class);
+    }
+
+    public function test_event_creation_allows_missing_security_guards(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+
+        $location = Location::factory()->create();
+
+        $response = $this->actingAs($user)->postJson('/api/events', [
+            'title' => 'Security Event',
+            'location_id' => $location->id,
+            'start_time' => now()->addDay()->toDateTimeString(),
+            'end_time' => now()->addDays(2)->toDateTimeString(),
+            'services' => [
+                [
+                    'service_type' => 'security',
+                    'details' => [
+                        'required' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(201);
+    }
+}


### PR DESCRIPTION
## Summary
- allow nullable `photography_type_id`
- add optional notes for photography services
- allow nullable guard counts for security
- test missing photography type
- test missing security guards

## Testing
- `vendor/bin/phpunit --stop-on-failure` *(fails: No such file or directory)*
- `composer install --no-interaction` *(fails to download packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688a76eee8d48333a1b567ca4ef4ecff