### PR TITLE
feat: add campus support and v2 location APIs

### DIFF
--- a/app/Http/Controllers/Api/V2/Admin/LocationController.php
+++ b/app/Http/Controllers/Api/V2/Admin/LocationController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api\V2\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V2\UpdateLocationRequest;
+use App\Models\Location;
+use App\Services\LocationService;
+use Illuminate\Http\JsonResponse;
+
+class LocationController extends Controller
+{
+    public function __construct(protected LocationService $service) {}
+
+    public function update(UpdateLocationRequest $request, Location $location): JsonResponse
+    {
+        $location = $this->service->update($location, $request->validated());
+        return response()->json(['message' => 'Location updated successfully', 'data' => $location]);
+    }
+}

--- a/app/Http/Controllers/Api/V2/LocationController.php
+++ b/app/Http/Controllers/Api/V2/LocationController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\Api\V2;
+
+use App\Http\Controllers\Controller;
+use App\Models\Location;
+use Illuminate\Http\JsonResponse;
+
+class LocationController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $locations = Location::with('campus')->get(['id','name','description','campus_id']);
+
+        return response()->json(['data' => $locations]);
+    }
+}

--- a/app/Http/Requests/V2/UpdateLocationRequest.php
+++ b/app/Http/Requests/V2/UpdateLocationRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\V2;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateLocationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->hasAnyRole(['Admin', 'Super Admin']);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|unique:locations,name,' . $this->location->id . '|max:255',
+            'campus_id' => 'required|exists:campuses,id',
+            'description' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Models/Campus.php
+++ b/app/Models/Campus.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Campus extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function locations()
+    {
+        return $this->hasMany(Location::class);
+    }
+}

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -5,15 +5,21 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Event;
+use App\Models\Campus;
 
 class Location extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name'];
+    protected $fillable = ['name', 'description', 'campus_id'];
 
     public function events()
     {
         return $this->hasMany(Event::class);
+    }
+
+    public function campus()
+    {
+        return $this->belongsTo(Campus::class);
     }
 }

--- a/app/Services/LocationService.php
+++ b/app/Services/LocationService.php
@@ -8,17 +8,31 @@ class LocationService
 {
     public function store(array $data): Location
     {
+        $data['description'] = $this->sanitizeDescription($data['description'] ?? null);
         return Location::create($data);
     }
 
     public function update(Location $location, array $data): Location
     {
+        if (array_key_exists('description', $data)) {
+            $data['description'] = $this->sanitizeDescription($data['description']);
+        }
         $location->update($data);
-        return $location;
+        return $location->fresh('campus');
     }
 
     public function delete(Location $location): void
     {
         $location->delete();
+    }
+
+    private function sanitizeDescription(?string $html): ?string
+    {
+        if ($html === null) {
+            return null;
+        }
+        $allowed = '<p><b><strong><i><em><u><ul><ol><li><br>';
+        $clean = strip_tags($html, $allowed);
+        return preg_replace('/<(\w+)[^>]*>/', '<$1>', $clean);
     }
 }

--- a/database/factories/CampusFactory.php
+++ b/database/factories/CampusFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Campus;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CampusFactory extends Factory
+{
+    protected $model = Campus::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->company,
+        ];
+    }
+}

--- a/database/factories/LocationFactory.php
+++ b/database/factories/LocationFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Location;
+use App\Models\Campus;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class LocationFactory extends Factory
@@ -13,6 +14,8 @@ class LocationFactory extends Factory
     {
         return [
             'name' => $this->faker->city,
+            'campus_id' => Campus::factory(),
+            'description' => '<p>'.$this->faker->sentence.'</p>',
         ];
     }
 }

--- a/database/migrations/2025_07_23_000000_create_campuses_table.php
+++ b/database/migrations/2025_07_23_000000_create_campuses_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('campuses', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('campuses');
+    }
+};

--- a/database/migrations/2025_07_23_010000_add_campus_id_and_description_to_locations_table.php
+++ b/database/migrations/2025_07_23_010000_add_campus_id_and_description_to_locations_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->foreignId('campus_id')->after('id')->constrained()->cascadeOnDelete();
+            $table->text('description')->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('campus_id');
+            $table->dropColumn('description');
+        });
+    }
+};

--- a/database/seeders/CampusSeeder.php
+++ b/database/seeders/CampusSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Campus;
+use Illuminate\Database\Seeder;
+
+class CampusSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $names = [
+            'Davisson Street Campus',
+            'Dalton Road Campus',
+            'SGC Campus',
+        ];
+
+        foreach ($names as $name) {
+            Campus::firstOrCreate(['name' => $name]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             RolesTableSeeder::class,
             UsersTableSeeder::class,
+            CampusSeeder::class,
         ]);
         // \App\Models\User::factory(10)->create();
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,8 @@ use App\Http\Controllers\Api\LocationController;
 use App\Http\Controllers\Api\AvailabilityController;
 use App\Http\Controllers\Api\Admin\AdminPhotographyTypeController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\V2\LocationController as V2LocationController;
+use App\Http\Controllers\Api\V2\Admin\LocationController as V2AdminLocationController;
 
 
 ///////////////Auth///////////////////////
@@ -36,6 +38,12 @@ Route::get('/auth/microsoft/callback', [MicrosoftAuthController::class, 'callbac
 Route::get('/locations', [LocationController::class, 'index']);
 Route::get('/photography-types', [\App\Http\Controllers\Api\PhotographyTypeController::class, 'index']);
 Route::get('/availability', [AvailabilityController::class, 'index']);
+
+Route::prefix('v2')->group(function () {
+    Route::get('/locations', [V2LocationController::class, 'index']);
+    Route::middleware(['auth:sanctum', 'role:Admin|Super Admin'])
+        ->put('/admin/locations/{location}', [V2AdminLocationController::class, 'update']);
+});
 
 //////////Events////////////////
 Route::middleware('auth:sanctum')->group(function () {


### PR DESCRIPTION
## Summary
- add Campus model, migrations, and seed default campuses
- extend locations with campus and HTML description and sanitize input
- expose v2 endpoints to list and update locations with campuses

## Testing
- `composer install` *(fails: nette/schema v1.3.0 requires php 8.1 - 8.3 -> your php version (8.4.11) does not satisfy that requirement)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68ac176b1a0083339ed262118a816514