### PR TITLE
Add campus support and safe HTML descriptions for locations

### DIFF
--- a/app/Enums/Campus.php
+++ b/app/Enums/Campus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum Campus: string
+{
+    case DAVISSON_STREET = 'Davisson Street Campus';
+    case DALTON_ROAD = 'Dalton Road Campus';
+    case SGC = 'SGC Campus';
+}

--- a/app/Http/Controllers/Api/Admin/AdminLocationController.php
+++ b/app/Http/Controllers/Api/Admin/AdminLocationController.php
@@ -22,8 +22,10 @@ class AdminLocationController extends Controller
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
-     *             required={"name"},
-     *             @OA\Property(property="name", type="string", example="Main Hall")
+     *             required={"name","campus"},
+     *             @OA\Property(property="name", type="string", example="Main Hall"),
+     *             @OA\Property(property="campus", type="string", example="Davisson Street Campus"),
+     *             @OA\Property(property="description", type="string", example="<p>Spacious hall</p>")
      *         )
      *     ),
      *     @OA\Response(
@@ -34,6 +36,8 @@ class AdminLocationController extends Controller
      *             @OA\Property(property="data", type="object",
      *                 @OA\Property(property="id", type="integer", example=1),
      *                 @OA\Property(property="name", type="string", example="Main Hall"),
+     *                 @OA\Property(property="campus", type="string", example="Davisson Street Campus"),
+     *                 @OA\Property(property="description", type="string", example="<p>Spacious hall</p>"),
      *                 @OA\Property(property="created_at", type="string", format="date-time"),
      *                 @OA\Property(property="updated_at", type="string", format="date-time")
      *             )
@@ -65,8 +69,10 @@ class AdminLocationController extends Controller
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
-     *             required={"name"},
-     *             @OA\Property(property="name", type="string", example="Updated Hall Name")
+     *             required={"name","campus"},
+     *             @OA\Property(property="name", type="string", example="Updated Hall Name"),
+     *             @OA\Property(property="campus", type="string", example="Dalton Road Campus"),
+     *             @OA\Property(property="description", type="string", example="<p>Updated description</p>")
      *         )
      *     ),
      *     @OA\Response(
@@ -77,6 +83,8 @@ class AdminLocationController extends Controller
      *             @OA\Property(property="data", type="object",
      *                 @OA\Property(property="id", type="integer", example=1),
      *                 @OA\Property(property="name", type="string", example="Updated Hall Name"),
+     *                 @OA\Property(property="campus", type="string", example="Dalton Road Campus"),
+     *                 @OA\Property(property="description", type="string", example="<p>Updated description</p>"),
      *                 @OA\Property(property="created_at", type="string", format="date-time"),
      *                 @OA\Property(property="updated_at", type="string", format="date-time")
      *             )

--- a/app/Http/Controllers/Api/LocationController.php
+++ b/app/Http/Controllers/Api/LocationController.php
@@ -10,14 +10,27 @@ use Illuminate\Http\JsonResponse;
  * @OA\Get(
  *     path="/api/locations",
  *     summary="List all locations",
- *     @OA\Response(response=200, description="List of locations")
+ *     @OA\Response(
+ *         response=200,
+ *         description="List of locations",
+ *         @OA\JsonContent(type="object",
+ *             @OA\Property(property="data", type="array",
+ *                 @OA\Items(type="object",
+ *                     @OA\Property(property="id", type="integer"),
+ *                     @OA\Property(property="name", type="string"),
+ *                     @OA\Property(property="description", type="string"),
+ *                     @OA\Property(property="campus", type="string")
+ *                 )
+ *             )
+ *         )
+ *     )
  * )
  */
 class LocationController extends Controller
 {
     public function index(): JsonResponse
     {
-        $locations = Location::select('id', 'name', 'description')->get();
+        $locations = Location::select('id', 'name', 'description', 'campus')->get();
 
         return response()->json(['data' => $locations]);
     }

--- a/app/Http/Requests/StoreLocationRequest.php
+++ b/app/Http/Requests/StoreLocationRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\Campus;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreLocationRequest extends FormRequest
 {
@@ -16,6 +18,7 @@ class StoreLocationRequest extends FormRequest
         return [
             'name' => 'required|string|unique:locations,name|max:255',
             'description' => 'nullable|string',
+            'campus' => ['required', 'string', Rule::in(array_column(Campus::cases(), 'value'))],
         ];
     }
 }

--- a/app/Http/Requests/UpdateLocationRequest.php
+++ b/app/Http/Requests/UpdateLocationRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\Campus;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateLocationRequest extends FormRequest
 {
@@ -16,6 +18,7 @@ class UpdateLocationRequest extends FormRequest
         return [
             'name' => 'required|string|unique:locations,name,' . $this->location->id . '|max:255',
             'description' => 'nullable|string',
+            'campus' => ['required', 'string', Rule::in(array_column(Campus::cases(), 'value'))],
         ];
     }
 }

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\Campus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Event;
@@ -10,7 +11,17 @@ class Location extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'description'];
+    protected $fillable = ['name', 'description', 'campus'];
+
+    protected $casts = [
+        'campus' => Campus::class,
+    ];
+
+    public function setDescriptionAttribute(?string $value): void
+    {
+        $allowed = '<p><a><b><strong><i><em><u><ul><ol><li><br><span>';
+        $this->attributes['description'] = $value ? strip_tags($value, $allowed) : null;
+    }
     
     public function events()
     {

--- a/database/factories/LocationFactory.php
+++ b/database/factories/LocationFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\Campus;
+use App\Models\Location;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Location>
+ */
+class LocationFactory extends Factory
+{
+    protected $model = Location::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->company . ' Hall',
+            'description' => '<p>' . $this->faker->sentence() . '</p>',
+            'campus' => $this->faker->randomElement(array_column(Campus::cases(), 'value')),
+        ];
+    }
+}

--- a/database/migrations/2025_08_25_000000_add_campus_and_description_to_locations_table.php
+++ b/database/migrations/2025_08_25_000000_add_campus_and_description_to_locations_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Enums\Campus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->enum('campus', [
+                Campus::DAVISSON_STREET->value,
+                Campus::DALTON_ROAD->value,
+                Campus::SGC->value,
+            ])->after('name');
+            $table->text('description')->nullable()->after('campus');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->dropColumn(['campus', 'description']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add Campus enum with three fixed values and associate locations with a campus
- sanitize and store HTML descriptions, exposing campus in APIs
- extend validation, migrations, factory, and documentation for campuses

## Testing
- `composer install --ignore-platform-reqs` *(fails: GitHub token required)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1ec5a50483338219d84644284439