### PR TITLE
feat: allow admins to update events

### DIFF
--- a/app/Http/Controllers/Api/Admin/AdminEventController.php
+++ b/app/Http/Controllers/Api/Admin/AdminEventController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\AdminUpdateEventRequest;
+use App\Http\Requests\StoreEventServiceRequest;
+use App\Models\Event;
+use App\Models\EventService as EventServiceModel;
+use App\Services\EventService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Validator;
+
+class AdminEventController extends Controller
+{
+    public function __construct(protected EventService $eventService) {}
+
+    /**
+     * @OA\Put(
+     *     path="/api/admin/events/{id}",
+     *     summary="Update an event",
+     *     tags={"Admin - Events"},
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(ref="#/components/schemas/AdminUpdateEventRequest")
+     *     ),
+     *     @OA\Response(response=200, description="Event updated successfully")
+     * )
+     */
+    public function update(AdminUpdateEventRequest $request, Event $event): JsonResponse
+    {
+        $data = $request->validated();
+
+        $updated = $this->eventService->update($event, $data);
+
+        foreach ($request->input('services', []) as $serviceData) {
+            $validator = Validator::make(
+                $serviceData,
+                (new StoreEventServiceRequest())->rules($serviceData['service_type'] ?? null)
+            );
+            $validated = $validator->validate();
+            $validated['event_id'] = $event->id;
+
+            EventServiceModel::updateOrCreate(
+                ['event_id' => $event->id, 'service_type' => $validated['service_type']],
+                $validated
+            );
+        }
+
+        return response()->json([
+            'message' => 'Event updated successfully',
+            'data' => $updated,
+        ]);
+    }
+}

--- a/app/Http/Requests/AdminUpdateEventRequest.php
+++ b/app/Http/Requests/AdminUpdateEventRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Models\Event;
+
+class AdminUpdateEventRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'sometimes|string|max:255',
+            'details' => 'nullable|string',
+            'expected_attendance' => 'nullable|integer|min:1',
+            'organizer_name' => 'nullable|string|max:255',
+            'organizer_email' => 'nullable|email|max:255',
+            'organizer_phone' => 'nullable|string|max:20',
+            'location_id' => 'sometimes|exists:locations,id',
+            'start_time' => 'sometimes|date|after_or_equal:now',
+            'end_time' => 'sometimes|date|after:start_time',
+            'services' => 'sometimes|array',
+            'status' => 'sometimes|in:pending,approved,rejected,cancelled,draft',
+            'user_id' => 'sometimes|exists:users,id',
+        ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            $event = $this->route('event');
+            $locationId = $this->input('location_id', $event->location_id ?? null);
+            $startTime = $this->input('start_time', $event->start_time ?? null);
+            $endTime = $this->input('end_time', $event->end_time ?? null);
+
+            if (!$locationId || !$startTime || !$endTime) {
+                return;
+            }
+
+            $conflict = Event::where('location_id', $locationId)
+                ->where('id', '!=', $event->id)
+                ->where('start_time', '<', $endTime)
+                ->where('end_time', '>', $startTime)
+                ->exists();
+
+            if ($conflict) {
+                $validator->errors()->add('start_time', 'The selected location is unavailable for the chosen time.');
+            }
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\Admin\AdminCalendarOverviewController;
 use App\Http\Controllers\Api\Admin\AdminEventApprovalController;
 use App\Http\Controllers\Api\Admin\AdminLocationController;
 use App\Http\Controllers\Api\Admin\AdminPendingEventsController;
+use App\Http\Controllers\Api\Admin\AdminEventController;
 use App\Http\Controllers\Api\Admin\AdminUserController;
 use App\Http\Controllers\Api\Admin\AdminRoleController;
 use App\Http\Controllers\Api\AuthController;
@@ -65,6 +66,7 @@ Route::middleware(['auth:sanctum', 'role:Admin|Super Admin'])->group(function ()
     Route::prefix('admin/events')->group(function () {
         Route::post('{event}/approve', [AdminEventApprovalController::class, 'approve']);
         Route::post('{event}/reject', [AdminEventApprovalController::class, 'reject']);
+        Route::put('{event}', [AdminEventController::class, 'update']);
     });
     Route::get('/admin/bookings', [AdminAllBookingsController::class, 'index']);
     Route::get('/admin/users', [AdminUserController::class, 'index']);

--- a/tests/Feature/AdminEventUpdateTest.php
+++ b/tests/Feature/AdminEventUpdateTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\Location;
+use App\Models\User;
+use Database\Seeders\RolesTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminEventUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        $this->artisan('migrate');
+        $this->seed(RolesTableSeeder::class);
+    }
+
+    public function test_admin_can_update_any_event(): void
+    {
+        $owner = User::factory()->create();
+        $owner->assignRole('General');
+        $admin = User::factory()->create();
+        $admin->assignRole('Admin');
+        $location = Location::factory()->create();
+        $event = Event::factory()->for($owner)->for($location)->create([
+            'title' => 'Original',
+            'start_time' => now()->addDays(5),
+            'end_time' => now()->addDays(6),
+            'status' => 'approved',
+        ]);
+
+        $response = $this->actingAs($admin)->putJson('/api/admin/events/' . $event->id, [
+            'title' => 'Updated Title',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertEquals('Updated Title', $event->fresh()->title);
+        $this->assertEquals('approved', $event->fresh()->status);
+    }
+
+    public function test_non_admin_cannot_use_admin_update(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('General');
+        $location = Location::factory()->create();
+        $event = Event::factory()->for($user)->for($location)->create([
+            'start_time' => now()->addDays(5),
+            'end_time' => now()->addDays(6),
+        ]);
+
+        $response = $this->actingAs($user)->putJson('/api/admin/events/' . $event->id, [
+            'title' => 'Fail Update',
+        ]);
+
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- add admin API endpoint to update any event
- allow updating all event fields and services
- test admin update authorization

## Testing
- `composer install --ignore-platform-reqs` *(fails: GitHub authentication token required)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac29b18188833388a025a53b314cf1