### PR TITLE
Add role filter to event search

### DIFF
--- a/app/Http/Controllers/Api/Admin/AdminAllBookingsController.php
+++ b/app/Http/Controllers/Api/Admin/AdminAllBookingsController.php
@@ -18,6 +18,8 @@ use Illuminate\Http\JsonResponse;
  *     @OA\Parameter(name="start_date", in="query", @OA\Schema(type="string", format="date")),
  *     @OA\Parameter(name="organizer_email", in="query", @OA\Schema(type="string", format="email")),
  *     @OA\Parameter(name="title", in="query", @OA\Schema(type="string")),
+ *     @OA\Parameter(name="search", in="query", @OA\Schema(type="string")),
+ *     @OA\Parameter(name="role", in="query", @OA\Schema(type="string", enum={"catering","photography","security"})),
  *     @OA\Response(response=200, description="List of bookings")
  * )
  */

--- a/app/Http/Requests/AdminBookingsRequest.php
+++ b/app/Http/Requests/AdminBookingsRequest.php
@@ -20,6 +20,7 @@ class AdminBookingsRequest extends FormRequest
             'organizer_email' => 'nullable|email',
             'title' => 'nullable|string|max:255',
             'search' => 'nullable|string|max:255',
+            'role' => 'nullable|in:catering,photography,security',
         ];
     }
 }

--- a/app/Http/Requests/FilterCalendarRequest.php
+++ b/app/Http/Requests/FilterCalendarRequest.php
@@ -24,6 +24,7 @@ class FilterCalendarRequest extends FormRequest
             'location_id' => 'nullable|exists:locations,id',
             'date' => 'nullable|date', // مثال: 2025-06-10
             'search' => 'nullable|string|max:255',
+            'role' => 'nullable|in:catering,photography,security',
         ];
     }
 }

--- a/app/Services/AdminBookingsService.php
+++ b/app/Services/AdminBookingsService.php
@@ -39,6 +39,12 @@ class AdminBookingsService
             });
         }
 
+        if (!empty($filters['role']) && in_array($filters['role'], ['catering', 'photography', 'security'])) {
+            $query->whereHas('services', function ($q) use ($filters) {
+                $q->where('service_type', $filters['role']);
+            });
+        }
+
         return $query->orderByDesc('created_at')->get();
     }
 }

--- a/tests/Feature/AdminBookingsRoleFilterTest.php
+++ b/tests/Feature/AdminBookingsRoleFilterTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\EventService;
+use App\Models\Location;
+use App\Models\User;
+use Database\Seeders\RolesTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminBookingsRoleFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+
+        $this->artisan('migrate');
+        $this->seed(RolesTableSeeder::class);
+    }
+
+    public function test_admin_can_filter_bookings_by_role(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('Admin');
+
+        $owner = User::factory()->create();
+        $owner->assignRole('General');
+
+        $location = Location::factory()->create();
+
+        $photoEvent = Event::create([
+            'user_id' => $owner->id,
+            'location_id' => $location->id,
+            'title' => 'Photo Event',
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDays(2),
+            'status' => 'pending',
+        ]);
+        EventService::create([
+            'event_id' => $photoEvent->id,
+            'service_type' => 'photography',
+        ]);
+
+        $cateringEvent = Event::create([
+            'user_id' => $owner->id,
+            'location_id' => $location->id,
+            'title' => 'Catering Event',
+            'start_time' => now()->addDays(3),
+            'end_time' => now()->addDays(4),
+            'status' => 'pending',
+        ]);
+        EventService::create([
+            'event_id' => $cateringEvent->id,
+            'service_type' => 'catering',
+        ]);
+
+        $response = $this->actingAs($admin)->getJson('/api/admin/bookings?role=photography');
+
+        $response->assertStatus(200);
+        $this->assertCount(1, $response->json('data'));
+        $this->assertEquals('Photo Event', $response->json('data.0.title'));
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow admin bookings API to filter events by required service role
- expose optional `role` filter on admin calendar view
- test admin bookings filtering by photography role

## Testing
- `php artisan test` *(fails: require vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3ab4ab608333bf185f2566eaaabd