### PR TITLE
Add CSV export for filtered events

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -59,6 +59,7 @@ Route::middleware('auth:sanctum')->post('/events/{event}/services', [EventServic
 ///////////////Dashboard - Admin//////////////////////////
 
 Route::middleware(['auth:sanctum', 'role:Super Admin|Admin|Catering|Photography|Security'])->get('/admin/calendar-view', [AdminCalendarController::class, 'index']);
+Route::middleware(['auth:sanctum', 'role:Super Admin|Admin|Catering|Photography|Security'])->get('/admin/calendar-view/export', [AdminCalendarController::class, 'export']);
 Route::middleware(['auth:sanctum', 'role:Super Admin|Admin|Catering|Photography|Security'])->get('/admin/calendar-overview', [AdminCalendarOverviewController::class, 'index']);
 
 Route::middleware(['auth:sanctum', 'role:Admin|Super Admin'])->group(function () {

--- a/tests/Feature/AdminCalendarExportTest.php
+++ b/tests/Feature/AdminCalendarExportTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\Location;
+use App\Models\User;
+use Database\Seeders\RolesTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminCalendarExportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        $this->artisan('migrate');
+        $this->seed(RolesTableSeeder::class);
+    }
+
+    public function test_admin_can_export_filtered_events(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('Admin');
+
+        $location = Location::factory()->create();
+
+        Event::factory()->for($admin)->for($location)->create([
+            'title' => 'Exportable Event',
+            'start_time' => now()->addDays(1),
+            'end_time' => now()->addDays(2),
+        ]);
+
+        $response = $this->actingAs($admin)->get('/api/admin/calendar-view/export');
+
+        $response->assertOk();
+        $response->assertHeader('content-type', 'text/csv');
+        $this->assertStringContainsString('Exportable Event', $response->streamedContent());
+    }
+}


### PR DESCRIPTION
## Summary
- allow admins to export filtered calendar events to CSV
- route for exporting search results
- test for admin event export

## Testing
- `phpunit` *(fails: command not found)*
- `composer install` *(fails: nette/schema requires php 8.1 - 8.3)*

------
https://chatgpt.com/codex/tasks/task_e_68ac46ae63208333b1ca33c0684db589