### PR TITLE
feat(events): expand event creation options

### DIFF
--- a/app/Http/Requests/AdminUpdateEventRequest.php
+++ b/app/Http/Requests/AdminUpdateEventRequest.php
@@ -4,6 +4,8 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use App\Models\Event;
+use Illuminate\Validation\Rules\Enum;
+use App\Enums\Campus;
 
 class AdminUpdateEventRequest extends FormRequest
 {
@@ -22,8 +24,12 @@ class AdminUpdateEventRequest extends FormRequest
             'organizer_email' => 'nullable|email|max:255',
             'organizer_phone' => 'nullable|string|max:20',
             'location_id' => 'sometimes|exists:locations,id',
+            'department_id' => 'sometimes|exists:departments,id',
+            'campus' => ['sometimes', new Enum(Campus::class)],
+            'security_note' => 'nullable|string',
             'start_time' => 'sometimes|date|after_or_equal:now',
             'end_time' => 'sometimes|date|after:start_time',
+            'end_date' => 'nullable|date|after_or_equal:start_time',
             'services' => 'sometimes|array',
             'status' => 'sometimes|in:pending,approved,rejected,cancelled,draft',
             'user_id' => 'sometimes|exists:users,id',
@@ -50,6 +56,16 @@ class AdminUpdateEventRequest extends FormRequest
 
             if ($conflict) {
                 $validator->errors()->add('start_time', 'The selected location is unavailable for the chosen time.');
+            }
+
+            $campus = $this->input('campus', $event->campus ?? null);
+            if ($campus && $locationId) {
+                $matches = \App\Models\Location::where('id', $locationId)
+                    ->where('campus', $campus)
+                    ->exists();
+                if (!$matches) {
+                    $validator->errors()->add('location_id', 'The selected location does not belong to the chosen campus.');
+                }
             }
         });
     }

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Department extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function events()
+    {
+        return $this->hasMany(Event::class);
+    }
+}
+

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -11,7 +11,9 @@ class Event extends Model
 
     protected $fillable = [
         'user_id',
+        'department_id',
         'location_id',
+        'campus',
         'title',
         'details',
         'expected_attendance',
@@ -20,12 +22,24 @@ class Event extends Model
         'organizer_phone',
         'start_time',
         'end_time',
+        'end_date',
+        'security_note',
         'status',
+    ];
+
+    protected $casts = [
+        'campus' => \App\Enums\Campus::class,
+        'end_date' => 'date',
     ];
 
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function department()
+    {
+        return $this->belongsTo(Department::class);
     }
 
     public function location()

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -4,33 +4,73 @@ namespace App\Services;
 
 use App\Models\Event;
 use App\Http\Requests\StoreEventRequest;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\EventApprovalRequest;
+use Carbon\Carbon;
 
 class EventService
 {
-    public function create(StoreEventRequest $request): Event
+    public function create(StoreEventRequest $request): array
     {
-        $event = Event::create([
-            'user_id' => $request->user()->id,
-            'location_id' => $request->location_id,
-            'title' => $request->title,
-            'details' => $request->details,
-            'expected_attendance' => $request->expected_attendance,
-            'organizer_name' => $request->organizer_name,
-            'organizer_email' => $request->organizer_email,
-            'organizer_phone' => $request->organizer_phone,
-            'start_time' => $request->start_time,
-            'end_time' => $request->end_time,
-            'status' => 'pending',
-        ]);
-        
-        // Notify all admins that a new event requires approval
-        $admins = \App\Models\User::role('Admin')->get();
-        if ($admins->isNotEmpty()) {
-            \Illuminate\Support\Facades\Mail::to($admins)
-                ->send(new \App\Mail\EventApprovalRequest($event));
+        $start = Carbon::parse($request->start_time);
+        $end = Carbon::parse($request->end_time);
+        $frequency = $request->recurrence_frequency;
+        $count = $request->recurrence_count ? (int) $request->recurrence_count : 1;
+        $interval = match ($frequency) {
+            'daily' => 1,
+            'weekly' => 7,
+            'fortnightly' => 14,
+            default => 0,
+        };
+
+        $created = [];
+        $conflicts = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $currentStart = (clone $start)->addDays($i * $interval);
+            $currentEnd = (clone $end)->addDays($i * $interval);
+            $currentEndDate = $request->end_date
+                ? Carbon::parse($request->end_date)->addDays($i * $interval)->toDateString()
+                : null;
+
+            $hasConflict = Event::where('location_id', $request->location_id)
+                ->where('start_time', '<', $currentEnd)
+                ->where('end_time', '>', $currentStart)
+                ->exists();
+
+            if ($hasConflict) {
+                $conflicts[] = $currentStart->toDateTimeString();
+                continue;
+            }
+
+            $event = Event::create([
+                'user_id' => $request->user()->id,
+                'location_id' => $request->location_id,
+                'department_id' => $request->department_id,
+                'campus' => $request->campus,
+                'title' => $request->title,
+                'details' => $request->details,
+                'expected_attendance' => $request->expected_attendance,
+                'organizer_name' => $request->organizer_name,
+                'organizer_email' => $request->organizer_email,
+                'organizer_phone' => $request->organizer_phone,
+                'security_note' => $request->security_note,
+                'start_time' => $currentStart,
+                'end_time' => $currentEnd,
+                'end_date' => $currentEndDate,
+                'status' => 'pending',
+            ]);
+
+            $admins = User::role('Admin')->get();
+            if ($admins->isNotEmpty()) {
+                Mail::to($admins)->send(new EventApprovalRequest($event));
+            }
+
+            $created[] = $event;
         }
 
-        return $event;
+        return [$created, $conflicts];
     }
 
     public function update(Event $event, array $data): Event

--- a/database/factories/DepartmentFactory.php
+++ b/database/factories/DepartmentFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Department;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Department>
+ */
+class DepartmentFactory extends Factory
+{
+    protected $model = Department::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->company,
+        ];
+    }
+}
+

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\User;
+use App\Models\Location;
+use App\Models\Department;
+use App\Enums\Campus;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Carbon\Carbon;
+
+/**
+ * @extends Factory<Event>
+ */
+class EventFactory extends Factory
+{
+    protected $model = Event::class;
+
+    public function definition(): array
+    {
+        $start = Carbon::instance($this->faker->dateTimeBetween('+1 days', '+2 days'));
+        $end = (clone $start)->addHours(2);
+
+        return [
+            'user_id' => User::factory(),
+            'location_id' => Location::factory(),
+            'department_id' => Department::factory(),
+            'campus' => $this->faker->randomElement(array_column(Campus::cases(), 'value')),
+            'title' => $this->faker->sentence,
+            'details' => $this->faker->paragraph,
+            'expected_attendance' => $this->faker->numberBetween(1, 100),
+            'organizer_name' => $this->faker->name,
+            'organizer_email' => $this->faker->safeEmail,
+            'organizer_phone' => $this->faker->phoneNumber,
+            'start_time' => $start,
+            'end_time' => $end,
+            'end_date' => $end->toDateString(),
+            'security_note' => $this->faker->sentence,
+            'status' => 'pending',
+        ];
+    }
+
+    public function configure()
+    {
+        return $this->afterMaking(function (Event $event) {
+            if ($event->location) {
+                $event->campus = $event->location->campus->value;
+            }
+        })->afterCreating(function (Event $event) {
+            if ($event->location) {
+                $event->campus = $event->location->campus->value;
+                $event->save();
+            }
+        });
+    }
+}
+

--- a/database/migrations/2025_09_01_000000_create_departments_table.php
+++ b/database/migrations/2025_09_01_000000_create_departments_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('departments', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('departments');
+    }
+};
+

--- a/database/migrations/2025_09_01_010000_add_department_campus_security_note_end_date_to_events_table.php
+++ b/database/migrations/2025_09_01_010000_add_department_campus_security_note_end_date_to_events_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Enums\Campus;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->foreignId('department_id')->after('user_id')->constrained()->onDelete('cascade');
+            $table->enum('campus', [
+                Campus::DAVISSON_STREET->value,
+                Campus::DALTON_ROAD->value,
+                Campus::SGC->value,
+            ])->after('location_id');
+            $table->date('end_date')->nullable()->after('end_time');
+            $table->text('security_note')->nullable()->after('end_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropForeign(['department_id']);
+            $table->dropColumn(['department_id','campus','end_date','security_note']);
+        });
+    }
+};
+

--- a/tests/Feature/AdminBookingsRoleFilterTest.php
+++ b/tests/Feature/AdminBookingsRoleFilterTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Event;
 use App\Models\EventService;
 use App\Models\Location;
+use App\Models\Department;
 use App\Models\User;
 use Database\Seeders\RolesTableSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -34,10 +35,13 @@ class AdminBookingsRoleFilterTest extends TestCase
         $owner->assignRole('General');
 
         $location = Location::factory()->create();
+        $department = Department::factory()->create();
 
         $photoEvent = Event::create([
             'user_id' => $owner->id,
             'location_id' => $location->id,
+            'department_id' => $department->id,
+            'campus' => $location->campus->value,
             'title' => 'Photo Event',
             'start_time' => now()->addDay(),
             'end_time' => now()->addDays(2),
@@ -51,6 +55,8 @@ class AdminBookingsRoleFilterTest extends TestCase
         $cateringEvent = Event::create([
             'user_id' => $owner->id,
             'location_id' => $location->id,
+            'department_id' => $department->id,
+            'campus' => $location->campus->value,
             'title' => 'Catering Event',
             'start_time' => now()->addDays(3),
             'end_time' => now()->addDays(4),

--- a/tests/Feature/AdminEmailNotificationTest.php
+++ b/tests/Feature/AdminEmailNotificationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Mail\EventApprovalRequest;
 use App\Models\Location;
+use App\Models\Department;
 use App\Models\User;
 use Database\Seeders\RolesTableSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -35,6 +36,7 @@ class AdminEmailNotificationTest extends TestCase
         $admin->assignRole('Admin');
 
         $location = Location::factory()->create();
+        $department = Department::factory()->create();
 
         $response = $this->actingAs($user)->postJson('/api/events', [
             'title' => 'Email Test',
@@ -42,6 +44,8 @@ class AdminEmailNotificationTest extends TestCase
             'start_time' => now()->addDays(15)->toDateTimeString(),
             'end_time' => now()->addDays(16)->toDateTimeString(),
             'expected_attendance' => 20,
+            'department_id' => $department->id,
+            'campus' => $location->campus->value,
         ]);
 
         $response->assertStatus(201);

--- a/tests/Feature/EventLeadTimeTest.php
+++ b/tests/Feature/EventLeadTimeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Location;
+use App\Models\Department;
 use App\Models\User;
 use Database\Seeders\RolesTableSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -29,12 +30,15 @@ class EventLeadTimeTest extends TestCase
         $user->assignRole('General');
 
         $location = Location::factory()->create();
+        $department = Department::factory()->create();
 
         $response = $this->actingAs($user)->postJson('/api/events', [
             'title' => 'Test Event',
             'location_id' => $location->id,
             'start_time' => now()->addDays(10)->toDateTimeString(),
             'end_time' => now()->addDays(11)->toDateTimeString(),
+            'department_id' => $department->id,
+            'campus' => $location->campus->value,
             'expected_attendance' => 40,
         ]);
 
@@ -53,6 +57,8 @@ class EventLeadTimeTest extends TestCase
             'location_id' => $location->id,
             'start_time' => now()->addDays(15)->toDateTimeString(),
             'end_time' => now()->addDays(16)->toDateTimeString(),
+            'department_id' => $department->id,
+            'campus' => $location->campus->value,
             'expected_attendance' => 40,
         ]);
 

--- a/tests/Feature/PhotographyTypeTest.php
+++ b/tests/Feature/PhotographyTypeTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use App\Models\Location;
 use App\Models\PhotographyType;
+use App\Models\Department;
 use Database\Seeders\RolesTableSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -43,12 +44,15 @@ class PhotographyTypeTest extends TestCase
         $user->assignRole('General');
 
         $location = Location::factory()->create();
+        $department = Department::factory()->create();
 
         $response = $this->actingAs($user)->postJson('/api/events', [
             'title' => 'Test',
             'location_id' => $location->id,
             'start_time' => now()->addDay()->toDateTimeString(),
             'end_time' => now()->addDays(2)->toDateTimeString(),
+            'department_id' => $department->id,
+            'campus' => $location->campus->value,
             'services' => [
                 [
                     'service_type' => 'photography',
@@ -69,12 +73,15 @@ class PhotographyTypeTest extends TestCase
         $user->assignRole('General');
 
         $location = Location::factory()->create();
+        $department = Department::factory()->create();
 
         $response = $this->actingAs($user)->postJson('/api/events', [
             'title' => 'Test',
             'location_id' => $location->id,
             'start_time' => now()->addDay()->toDateTimeString(),
             'end_time' => now()->addDays(2)->toDateTimeString(),
+            'department_id' => $department->id,
+            'campus' => $location->campus->value,
             'services' => [
                 [
                     'service_type' => 'photography',

--- a/tests/Feature/SecurityServiceTest.php
+++ b/tests/Feature/SecurityServiceTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use App\Models\Location;
+use App\Models\Department;
 use Database\Seeders\RolesTableSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -29,12 +30,15 @@ class SecurityServiceTest extends TestCase
         $user->assignRole('General');
 
         $location = Location::factory()->create();
+        $department = Department::factory()->create();
 
         $response = $this->actingAs($user)->postJson('/api/events', [
             'title' => 'Security Event',
             'location_id' => $location->id,
             'start_time' => now()->addDay()->toDateTimeString(),
             'end_time' => now()->addDays(2)->toDateTimeString(),
+            'department_id' => $department->id,
+            'campus' => $location->campus->value,
             'services' => [
                 [
                     'service_type' => 'security',


### PR DESCRIPTION
## Summary
- allow choosing department and campus when creating events
- support optional end date, security notes, and recurring event scheduling
- add department model and migrations for new event fields

## Testing
- `composer install` *(fails: nette/schema v1.3.0 requires php 8.1 - 8.3 -> your php version (8.4.11) does not satisfy that requirement)*


------
https://chatgpt.com/codex/tasks/task_e_68ac5fbda1d88333972eaa45928a059e