### PR TITLE
Store department name on events

### DIFF
--- a/app/Http/Requests/AdminUpdateEventRequest.php
+++ b/app/Http/Requests/AdminUpdateEventRequest.php
@@ -24,7 +24,7 @@ class AdminUpdateEventRequest extends FormRequest
             'organizer_email' => 'nullable|email|max:255',
             'organizer_phone' => 'nullable|string|max:20',
             'location_id' => 'sometimes|exists:locations,id',
-            'department_id' => 'sometimes|exists:departments,id',
+            'department' => 'sometimes|string|max:255',
             'campus' => ['sometimes', new Enum(Campus::class)],
             'security_note' => 'nullable|string',
             'start_time' => 'sometimes|date|after_or_equal:now',

--- a/app/Http/Requests/StoreEventRequest.php
+++ b/app/Http/Requests/StoreEventRequest.php
@@ -34,7 +34,7 @@ class StoreEventRequest extends FormRequest
             'organizer_email' => 'nullable|email|max:255',
             'organizer_phone' => 'nullable|string|max:20',
             'location_id' => 'required|exists:locations,id',
-            'department_id' => 'required|exists:departments,id',
+            'department' => 'required|string|max:255',
             'campus' => ['required', new Enum(Campus::class)],
             'security_note' => 'nullable|string',
             'start_time' => [

--- a/app/Http/Requests/UpdateEventRequest.php
+++ b/app/Http/Requests/UpdateEventRequest.php
@@ -24,7 +24,7 @@ class UpdateEventRequest extends FormRequest
             'organizer_email' => 'nullable|email|max:255',
             'organizer_phone' => 'nullable|string|max:20',
             'location_id' => 'sometimes|exists:locations,id',
-            'department_id' => 'sometimes|exists:departments,id',
+            'department' => 'sometimes|string|max:255',
             'campus' => ['sometimes', new Enum(Campus::class)],
             'security_note' => 'nullable|string',
             'start_time' => 'sometimes|date|after_or_equal:now',

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -11,7 +11,7 @@ class Event extends Model
 
     protected $fillable = [
         'user_id',
-        'department_id',
+        'department',
         'location_id',
         'campus',
         'title',
@@ -35,11 +35,6 @@ class Event extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
-    }
-
-    public function department()
-    {
-        return $this->belongsTo(Department::class);
     }
 
     public function location()

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -47,7 +47,7 @@ class EventService
             $event = Event::create([
                 'user_id' => $request->user()->id,
                 'location_id' => $request->location_id,
-                'department_id' => $request->department_id,
+                'department' => $request->department,
                 'campus' => $request->campus,
                 'title' => $request->title,
                 'details' => $request->details,

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -25,7 +25,7 @@ class EventFactory extends Factory
         return [
             'user_id' => User::factory(),
             'location_id' => Location::factory(),
-            'department_id' => Department::factory(),
+            'department' => Department::factory()->create()->name,
             'campus' => $this->faker->randomElement(array_column(Campus::cases(), 'value')),
             'title' => $this->faker->sentence,
             'details' => $this->faker->paragraph,

--- a/database/migrations/2025_09_01_020000_replace_department_id_with_department_in_events_table.php
+++ b/database/migrations/2025_09_01_020000_replace_department_id_with_department_in_events_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            if (Schema::hasColumn('events', 'department_id')) {
+                $table->dropForeign(['department_id']);
+                $table->dropColumn('department_id');
+            }
+        });
+
+        Schema::table('events', function (Blueprint $table) {
+            $table->string('department')->after('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('department');
+            $table->foreignId('department_id')->after('user_id')->constrained()->onDelete('cascade');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             RolesTableSeeder::class,
             UsersTableSeeder::class,
+            DepartmentsTableSeeder::class,
         ]);
         // \App\Models\User::factory(10)->create();
 

--- a/database/seeders/DepartmentsTableSeeder.php
+++ b/database/seeders/DepartmentsTableSeeder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Department;
+use Illuminate\Database\Seeder;
+
+class DepartmentsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $departments = [
+            'Principal\'s Office',
+            'DRC Administration',
+            'DSC Administration',
+            'SGC Administration',
+            'Business Manager',
+            'Curriculum & Information Technology',
+            'Careers',
+            'Future Technologies',
+            'Senior Studies',
+            'Learning Diversity',
+            'Faith and Religious Education',
+            'English',
+            'Commerce',
+            'Humanities',
+            'Languages',
+            'Performing Arts',
+            'Visual Arts',
+            'Hospitality',
+            'Digital Technologies',
+            'Health',
+            'Physical Education',
+            'Mathematics',
+            'Science',
+            'Technology & Engineering',
+            'Innovative Learning',
+            'Acutis',
+            'Badano Program',
+            'HORIZONS & Accelerated Learning',
+            'Inclusive Education',
+            'Library Services',
+            'Takada Homestay',
+            'Logistics Administrator Phillip Di Natale',
+            'Pedagogical Coach Amie Panayiotis',
+            'Pre & Specialised Testing Coordinator Kyra Farquharson',
+            'STEM',
+            'Wellbeing',
+            'Career Development',
+            'Promotions & Events',
+            'Alternate Department',
+            'Identity, Mission &Community',
+            'Professional Practice',
+            'Staffing & Administrative Logistics',
+            'Co-Curricular Activities & International Perspectives',
+        ];
+
+        foreach ($departments as $department) {
+            Department::firstOrCreate(['name' => $department]);
+        }
+    }
+}
+

--- a/tests/Feature/AdminBookingsRoleFilterTest.php
+++ b/tests/Feature/AdminBookingsRoleFilterTest.php
@@ -40,7 +40,7 @@ class AdminBookingsRoleFilterTest extends TestCase
         $photoEvent = Event::create([
             'user_id' => $owner->id,
             'location_id' => $location->id,
-            'department_id' => $department->id,
+            'department' => $department->name,
             'campus' => $location->campus->value,
             'title' => 'Photo Event',
             'start_time' => now()->addDay(),
@@ -55,7 +55,7 @@ class AdminBookingsRoleFilterTest extends TestCase
         $cateringEvent = Event::create([
             'user_id' => $owner->id,
             'location_id' => $location->id,
-            'department_id' => $department->id,
+            'department' => $department->name,
             'campus' => $location->campus->value,
             'title' => 'Catering Event',
             'start_time' => now()->addDays(3),

--- a/tests/Feature/AdminEmailNotificationTest.php
+++ b/tests/Feature/AdminEmailNotificationTest.php
@@ -44,7 +44,7 @@ class AdminEmailNotificationTest extends TestCase
             'start_time' => now()->addDays(15)->toDateTimeString(),
             'end_time' => now()->addDays(16)->toDateTimeString(),
             'expected_attendance' => 20,
-            'department_id' => $department->id,
+            'department' => $department->name,
             'campus' => $location->campus->value,
         ]);
 

--- a/tests/Feature/EventLeadTimeTest.php
+++ b/tests/Feature/EventLeadTimeTest.php
@@ -37,7 +37,7 @@ class EventLeadTimeTest extends TestCase
             'location_id' => $location->id,
             'start_time' => now()->addDays(10)->toDateTimeString(),
             'end_time' => now()->addDays(11)->toDateTimeString(),
-            'department_id' => $department->id,
+            'department' => $department->name,
             'campus' => $location->campus->value,
             'expected_attendance' => 40,
         ]);
@@ -51,13 +51,14 @@ class EventLeadTimeTest extends TestCase
         $user->assignRole('General');
 
         $location = Location::factory()->create();
+        $department = Department::factory()->create();
 
         $response = $this->actingAs($user)->postJson('/api/events', [
             'title' => 'Allowed Event',
             'location_id' => $location->id,
             'start_time' => now()->addDays(15)->toDateTimeString(),
             'end_time' => now()->addDays(16)->toDateTimeString(),
-            'department_id' => $department->id,
+            'department' => $department->name,
             'campus' => $location->campus->value,
             'expected_attendance' => 40,
         ]);

--- a/tests/Feature/PhotographyTypeTest.php
+++ b/tests/Feature/PhotographyTypeTest.php
@@ -51,7 +51,7 @@ class PhotographyTypeTest extends TestCase
             'location_id' => $location->id,
             'start_time' => now()->addDay()->toDateTimeString(),
             'end_time' => now()->addDays(2)->toDateTimeString(),
-            'department_id' => $department->id,
+            'department' => $department->name,
             'campus' => $location->campus->value,
             'services' => [
                 [
@@ -80,7 +80,7 @@ class PhotographyTypeTest extends TestCase
             'location_id' => $location->id,
             'start_time' => now()->addDay()->toDateTimeString(),
             'end_time' => now()->addDays(2)->toDateTimeString(),
-            'department_id' => $department->id,
+            'department' => $department->name,
             'campus' => $location->campus->value,
             'services' => [
                 [

--- a/tests/Feature/SecurityServiceTest.php
+++ b/tests/Feature/SecurityServiceTest.php
@@ -37,7 +37,7 @@ class SecurityServiceTest extends TestCase
             'location_id' => $location->id,
             'start_time' => now()->addDay()->toDateTimeString(),
             'end_time' => now()->addDays(2)->toDateTimeString(),
-            'department_id' => $department->id,
+            'department' => $department->name,
             'campus' => $location->campus->value,
             'services' => [
                 [


### PR DESCRIPTION
## Summary
- replace `department_id` foreign key with string `department` on events
- update models, requests, services, factory, and tests to use department name
- add migration to remove the department relation and store the name directly

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test` *(fails: Failed opening required '/workspace/smc-booking/vendor/autoload.php')*
- `composer install` *(fails: nette/schema v1.3.0 requires php 8.1 - 8.3, current php is 8.4.11)*

------
https://chatgpt.com/codex/tasks/task_e_68ad616fb1e88333825942c2c1fb6f35