### PR TITLE
Add campus and location booking APIs

### DIFF
--- a/app/Http/Controllers/Api/LocationController.php
+++ b/app/Http/Controllers/Api/LocationController.php
@@ -4,7 +4,10 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Location;
+use App\Models\Event;
+use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 /**
  * @OA\Get(
@@ -33,5 +36,42 @@ class LocationController extends Controller
         $locations = Location::select('id', 'name', 'description', 'campus')->get();
 
         return response()->json(['data' => $locations]);
+    }
+
+    /**
+     * Return campuses with their locations
+     */
+    public function campuses(): JsonResponse
+    {
+        $campuses = Location::select('id', 'name', 'description', 'campus')
+            ->get()
+            ->groupBy('campus')
+            ->map(fn ($locations, $campus) => [
+                'campus' => $campus,
+                'locations' => $locations->map(fn ($location) => $location->only(['id', 'name', 'description']))->values(),
+            ])
+            ->values();
+
+        return response()->json(['data' => $campuses]);
+    }
+
+    /**
+     * Return booked days for a location in a given month
+     */
+    public function bookedDays(Location $location, Request $request): JsonResponse
+    {
+        $month = $request->query('month');
+
+        $start = Carbon::parse($month . '-01')->startOfMonth();
+        $end = Carbon::parse($month . '-01')->endOfMonth();
+
+        $days = Event::where('location_id', $location->id)
+            ->whereBetween('start_time', [$start, $end])
+            ->pluck('start_time')
+            ->map(fn ($date) => Carbon::parse($date)->day)
+            ->unique()
+            ->values();
+
+        return response()->json(['data' => $days]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -35,6 +35,8 @@ Route::get('/auth/microsoft/callback', [MicrosoftAuthController::class, 'callbac
 
 // Locations
 Route::get('/locations', [LocationController::class, 'index']);
+Route::get('/campuses', [LocationController::class, 'campuses']);
+Route::get('/locations/{location}/booked-days', [LocationController::class, 'bookedDays']);
 Route::get('/photography-types', [\App\Http\Controllers\Api\PhotographyTypeController::class, 'index']);
 Route::get('/availability', [AvailabilityController::class, 'index']);
 //////////Events////////////////


### PR DESCRIPTION
## Summary
- Add endpoint to list campuses with their locations
- Add endpoint to fetch booked days for a location in a month

## Testing
- `php artisan test` *(fails: require vendor autoload)*
- `composer install --ignore-platform-req=php` *(fails: GitHub 403 during package download)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8f5a7b1c8333a227dfc7dac8a222