### PR TITLE
Store event location as text

### DIFF
--- a/app/Http/Controllers/Api/Admin/AdminAllBookingsController.php
+++ b/app/Http/Controllers/Api/Admin/AdminAllBookingsController.php
@@ -14,7 +14,7 @@ use Illuminate\Http\JsonResponse;
  *     tags={"Admin - Events"},
  *     security={{"sanctum":{}}},
  *     @OA\Parameter(name="status", in="query", @OA\Schema(type="string", enum={"pending","service_approved","approved","rejected","cancelled","draft"})),
- *     @OA\Parameter(name="location_id", in="query", @OA\Schema(type="integer")),
+ *     @OA\Parameter(name="location", in="query", @OA\Schema(type="string")),
  *     @OA\Parameter(name="start_date", in="query", @OA\Schema(type="string", format="date")),
  *     @OA\Parameter(name="organizer_email", in="query", @OA\Schema(type="string", format="email")),
  *     @OA\Parameter(name="title", in="query", @OA\Schema(type="string")),

--- a/app/Http/Controllers/Api/Admin/AdminCalendarController.php
+++ b/app/Http/Controllers/Api/Admin/AdminCalendarController.php
@@ -21,10 +21,10 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  *         @OA\Schema(type="string", enum={"draft","pending","service_approved","approved","rejected","cancelled"})
  *     ),
  *     @OA\Parameter(
- *         name="location_id",
+ *         name="location",
  *         in="query",
  *         required=false,
- *         @OA\Schema(type="integer")
+ *         @OA\Schema(type="string")
  *     ),
  *     @OA\Parameter(
  *         name="date",
@@ -105,7 +105,7 @@ class AdminCalendarController extends Controller
                     $event->start_time,
                     $event->end_time,
                     $event->status,
-                    optional($event->location)->name,
+                    $event->location,
                     optional($event->user)->name,
                 ]);
             }

--- a/app/Http/Controllers/Api/Admin/AdminCalendarOverviewController.php
+++ b/app/Http/Controllers/Api/Admin/AdminCalendarOverviewController.php
@@ -20,10 +20,10 @@ use Illuminate\Http\JsonResponse;
  *         @OA\Schema(type="string", enum={"draft","pending","service_approved","approved","rejected","cancelled"})
  *     ),
  *     @OA\Parameter(
- *         name="location_id",
+ *         name="location",
  *         in="query",
  *         required=false,
- *         @OA\Schema(type="integer")
+ *         @OA\Schema(type="string")
  *     ),
  *     @OA\Parameter(
  *         name="date",

--- a/app/Http/Controllers/Api/Admin/AdminPendingEventsController.php
+++ b/app/Http/Controllers/Api/Admin/AdminPendingEventsController.php
@@ -14,10 +14,10 @@ use Illuminate\Http\JsonResponse;
  *     tags={"Admin - Events"},
  *     security={{"sanctum":{}}},
  *     @OA\Parameter(
- *         name="location_id",
+ *         name="location",
  *         in="query",
  *         required=false,
- *         @OA\Schema(type="integer")
+ *         @OA\Schema(type="string")
  *     ),
  *     @OA\Parameter(
  *         name="start_date",

--- a/app/Http/Controllers/Api/EventController.php
+++ b/app/Http/Controllers/Api/EventController.php
@@ -159,7 +159,7 @@ class EventController extends Controller
      */
     public function myBookings(Request $request): JsonResponse
     {
-        $bookings = Event::with('location', 'services')
+        $bookings = Event::with('services')
             ->where('user_id', $request->user()->id)
             ->orderByDesc('created_at')
             ->get();
@@ -194,7 +194,7 @@ class EventController extends Controller
             return response()->json(['error' => 'You are not authorized to view this event.'], 403);
         }
 
-        $event->load('location', 'services');
+        $event->load('services');
 
         return response()->json(['data' => $event]);
     }

--- a/app/Http/Controllers/Api/LocationController.php
+++ b/app/Http/Controllers/Api/LocationController.php
@@ -65,7 +65,7 @@ class LocationController extends Controller
         $start = Carbon::parse($month . '-01')->startOfMonth();
         $end = Carbon::parse($month . '-01')->endOfMonth();
 
-        $days = Event::where('location_id', $location->id)
+        $days = Event::where('location', $location->name)
             ->whereBetween('start_time', [$start, $end])
             ->pluck('start_time')
             ->map(fn ($date) => Carbon::parse($date)->day)

--- a/app/Http/Controllers/Api/Staff/MyAssignmentsController.php
+++ b/app/Http/Controllers/Api/Staff/MyAssignmentsController.php
@@ -21,10 +21,10 @@ use Illuminate\Support\Facades\Auth;
  *         @OA\Schema(type="string", enum={"draft","pending","approved","rejected","cancelled"})
  *     ),
  *     @OA\Parameter(
- *         name="location_id",
+ *         name="location",
  *         in="query",
  *         required=false,
- *         @OA\Schema(type="integer")
+ *         @OA\Schema(type="string")
  *     ),
  *     @OA\Parameter(
  *         name="date",

--- a/app/Http/Requests/AdminBookingsRequest.php
+++ b/app/Http/Requests/AdminBookingsRequest.php
@@ -15,7 +15,7 @@ class AdminBookingsRequest extends FormRequest
     {
         return [
             'status' => 'nullable|in:pending,service_approved,approved,rejected,cancelled,draft',
-            'location_id' => 'nullable|exists:locations,id',
+            'location' => 'nullable|string|max:255',
             'start_date' => 'nullable|date',
             'organizer_email' => 'nullable|email',
             'title' => 'nullable|string|max:255',

--- a/app/Http/Requests/AdminUpdateEventRequest.php
+++ b/app/Http/Requests/AdminUpdateEventRequest.php
@@ -23,7 +23,7 @@ class AdminUpdateEventRequest extends FormRequest
             'organizer_name' => 'nullable|string|max:255',
             'organizer_email' => 'nullable|email|max:255',
             'organizer_phone' => 'nullable|string|max:20',
-            'location_id' => 'sometimes|exists:locations,id',
+            'location' => 'sometimes|string|max:255',
             'department' => 'sometimes|string|max:255',
             'campus' => ['sometimes', new Enum(Campus::class)],
             'security_note' => 'nullable|string',
@@ -56,15 +56,15 @@ class AdminUpdateEventRequest extends FormRequest
     {
         $validator->after(function ($validator) {
             $event = $this->route('event');
-            $locationId = $this->input('location_id', $event->location_id ?? null);
+            $location = $this->input('location', $event->location ?? null);
             $startTime = $this->input('start_time', $event->start_time ?? null);
             $endTime = $this->input('end_time', $event->end_time ?? null);
 
-            if (!$locationId || !$startTime || !$endTime) {
+            if (!$location || !$startTime || !$endTime) {
                 return;
             }
 
-            $conflict = Event::where('location_id', $locationId)
+            $conflict = Event::where('location', $location)
                 ->where('id', '!=', $event->id)
                 ->where('start_time', '<', $endTime)
                 ->where('end_time', '>', $startTime)
@@ -74,15 +74,6 @@ class AdminUpdateEventRequest extends FormRequest
                 $validator->errors()->add('start_time', 'The selected location is unavailable for the chosen time.');
             }
 
-            $campus = $this->input('campus', $event->campus ?? null);
-            if ($campus && $locationId) {
-                $matches = \App\Models\Location::where('id', $locationId)
-                    ->where('campus', $campus)
-                    ->exists();
-                if (!$matches) {
-                    $validator->errors()->add('location_id', 'The selected location does not belong to the chosen campus.');
-                }
-            }
         });
     }
 }

--- a/app/Http/Requests/FilterCalendarRequest.php
+++ b/app/Http/Requests/FilterCalendarRequest.php
@@ -21,7 +21,7 @@ class FilterCalendarRequest extends FormRequest
     {
         return [
             'status' => 'nullable|in:pending,service_approved,approved,rejected,cancelled,draft',
-            'location_id' => 'nullable|exists:locations,id',
+            'location' => 'nullable|string|max:255',
             'date' => 'nullable|date', // مثال: 2025-06-10
             'search' => 'nullable|string|max:255',
             'role' => 'nullable|in:catering,photography,security',

--- a/app/Http/Requests/FilterMyAssignmentsRequest.php
+++ b/app/Http/Requests/FilterMyAssignmentsRequest.php
@@ -15,7 +15,7 @@ class FilterMyAssignmentsRequest extends FormRequest
     {
         return [
             'status' => 'nullable|in:pending,approved,rejected,cancelled,draft',
-            'location_id' => 'nullable|exists:locations,id',
+            'location' => 'nullable|string|max:255',
             'date' => 'nullable|date',
             'query' => 'nullable|string|max:255',
         ];

--- a/app/Http/Requests/PendingEventsRequest.php
+++ b/app/Http/Requests/PendingEventsRequest.php
@@ -14,7 +14,7 @@ class PendingEventsRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'location_id' => 'nullable|exists:locations,id',
+            'location' => 'nullable|string|max:255',
             'start_date' => 'nullable|date',
             'title' => 'nullable|string|max:255',
             'organizer_email' => 'nullable|email',

--- a/app/Http/Requests/StoreEventRequest.php
+++ b/app/Http/Requests/StoreEventRequest.php
@@ -5,7 +5,6 @@ namespace App\Http\Requests;
 use Illuminate\Foundation\Http\FormRequest;
 use App\Rules\LocationAvailable;
 use App\Rules\EventLeadTime;
-use App\Models\Event;
 use Illuminate\Validation\Rules\Enum;
 use App\Enums\Campus;
 
@@ -33,7 +32,7 @@ class StoreEventRequest extends FormRequest
             'organizer_name' => 'nullable|string|max:255',
             'organizer_email' => 'nullable|email|max:255',
             'organizer_phone' => 'nullable|string|max:20',
-            'location_id' => 'required|exists:locations,id',
+            'location' => 'required|string|max:255',
             'department' => 'required|string|max:255',
             'campus' => ['required', new Enum(Campus::class)],
             'security_note' => 'nullable|string',
@@ -64,7 +63,7 @@ class StoreEventRequest extends FormRequest
                 'required',
                 'date',
                 'after_or_equal:start_time',
-                new LocationAvailable($this->location_id, $this->start_time, $this->end_time)
+                new LocationAvailable($this->location, $this->start_time, $this->end_time)
             ],
             'recurrence_frequency' => 'nullable|in:daily,weekly,fortnightly',
             'recurrence_count' => 'nullable|integer|min:1|max:52|required_with:recurrence_frequency',
@@ -72,30 +71,4 @@ class StoreEventRequest extends FormRequest
         ];
     }
 
-    public function withValidator($validator)
-    {
-        $validator->after(function ($validator) {
-            if (!$this->location_id || !$this->start_time || !$this->end_time) {
-                return;
-            }
-
-            $conflict = Event::where('location_id', $this->location_id)
-                ->where('start_time', '<', $this->end_time)
-                ->where('end_time', '>', $this->start_time)
-                ->exists();
-
-            if ($conflict) {
-                $validator->errors()->add('start_time', 'The selected location is unavailable for the chosen time.');
-            }
-
-            if ($this->campus && $this->location_id) {
-                $matches = \App\Models\Location::where('id', $this->location_id)
-                    ->where('campus', $this->campus)
-                    ->exists();
-                if (!$matches) {
-                    $validator->errors()->add('location_id', 'The selected location does not belong to the chosen campus.');
-                }
-            }
-        });
-    }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -12,7 +12,7 @@ class Event extends Model
     protected $fillable = [
         'user_id',
         'department',
-        'location_id',
+        'location',
         'campus',
         'title',
         'details',
@@ -39,11 +39,6 @@ class Event extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
-    }
-
-    public function location()
-    {
-        return $this->belongsTo(Location::class);
     }
 
     public function services()

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -24,6 +24,6 @@ class Location extends Model
     
     public function events()
     {
-        return $this->hasMany(Event::class);
+        return $this->hasMany(Event::class, 'location', 'name');
     }
 }

--- a/app/Rules/LocationAvailable.php
+++ b/app/Rules/LocationAvailable.php
@@ -7,14 +7,14 @@ use App\Models\Event;
 
 class LocationAvailable implements Rule
 {
-    protected int $locationId;
+    protected string $location;
     protected string $startTime;
     protected string $endTime;
     protected ?int $ignoreEventId;
 
-    public function __construct($locationId, $startTime, $endTime, $ignoreEventId = null)
+    public function __construct($location, $startTime, $endTime, $ignoreEventId = null)
     {
-        $this->locationId = $locationId;
+        $this->location = $location;
         $this->startTime = $startTime;
         $this->endTime = $endTime;
         $this->ignoreEventId = $ignoreEventId;
@@ -22,11 +22,11 @@ class LocationAvailable implements Rule
 
     public function passes($attribute, $value)
     {
-        if (!$this->locationId || !$this->startTime || !$this->endTime) {
+        if (!$this->location || !$this->startTime || !$this->endTime) {
             return true; // other validation will handle required fields
         }
 
-        $query = Event::where('location_id', $this->locationId)
+        $query = Event::where('location', $this->location)
             ->where('start_time', '<', $this->endTime)
             ->where('end_time', '>', $this->startTime);
 

--- a/app/Services/AdminBookingsService.php
+++ b/app/Services/AdminBookingsService.php
@@ -9,14 +9,14 @@ class AdminBookingsService
 {
     public function getFiltered(array $filters): Collection
     {
-        $query = Event::with('location', 'user', 'services');
+        $query = Event::with('user', 'services');
 
         if (!empty($filters['status'])) {
             $query->where('status', $filters['status']);
         }
 
-        if (!empty($filters['location_id'])) {
-            $query->where('location_id', $filters['location_id']);
+        if (!empty($filters['location'])) {
+            $query->where('location', $filters['location']);
         }
 
         if (!empty($filters['start_date'])) {

--- a/app/Services/AdminCalendarOverviewService.php
+++ b/app/Services/AdminCalendarOverviewService.php
@@ -10,14 +10,14 @@ class AdminCalendarOverviewService
 {
     public function getOverview(array $filters, ?string $role = null): Collection
     {
-        $query = Event::with('location', 'user', 'services');
+        $query = Event::with('user', 'services');
 
         if (!empty($filters['status'])) {
             $query->where('status', $filters['status']);
         }
 
-        if (!empty($filters['location_id'])) {
-            $query->where('location_id', $filters['location_id']);
+        if (!empty($filters['location'])) {
+            $query->where('location', $filters['location']);
         }
 
         if (!empty($filters['date'])) {

--- a/app/Services/AdminCalendarService.php
+++ b/app/Services/AdminCalendarService.php
@@ -10,14 +10,14 @@ class AdminCalendarService
 {
     public function getFilteredEvents(array $filters, ?string $role = null): Collection
     {
-        $query = Event::with('location', 'user', 'services');
+        $query = Event::with('user', 'services');
 
         if (!empty($filters['status'])) {
             $query->where('status', $filters['status']);
         }
 
-        if (!empty($filters['location_id'])) {
-            $query->where('location_id', $filters['location_id']);
+        if (!empty($filters['location'])) {
+            $query->where('location', $filters['location']);
         }
 
         if (!empty($filters['date'])) {

--- a/app/Services/AdminPendingEventsService.php
+++ b/app/Services/AdminPendingEventsService.php
@@ -9,7 +9,7 @@ class AdminPendingEventsService
 {
     public function getFiltered(array $filters): Collection
     {
-        $query = Event::with('location', 'user');
+        $query = Event::with('user');
 
         if (!empty($filters['status'])) {
             $query->where('status', $filters['status']);
@@ -17,8 +17,8 @@ class AdminPendingEventsService
             $query->where('status', 'pending');
         }
 
-        if (!empty($filters['location_id'])) {
-            $query->where('location_id', $filters['location_id']);
+        if (!empty($filters['location'])) {
+            $query->where('location', $filters['location']);
         }
 
         if (!empty($filters['start_date'])) {

--- a/app/Services/AssignmentService.php
+++ b/app/Services/AssignmentService.php
@@ -9,7 +9,7 @@ class AssignmentService
 {
     public function getMyAssignedEvents(int $userId, string $role, array $filters = []): Collection
     {
-        $query = Event::with(['location', 'user', 'services'])
+        $query = Event::with(['user', 'services'])
             ->whereHas('services', function ($q) use ($userId, $role) {
                 $q->where('assigned_to', $userId)
                   ->where('service_type', $role);
@@ -19,8 +19,8 @@ class AssignmentService
             $query->where('status', $filters['status']);
         }
 
-        if (!empty($filters['location_id'])) {
-            $query->where('location_id', $filters['location_id']);
+        if (!empty($filters['location'])) {
+            $query->where('location', $filters['location']);
         }
 
         if (!empty($filters['date'])) {

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -31,7 +31,7 @@ class EventService
             $currentStart = (clone $start)->addDays($i * $interval);
             $currentEnd = (clone $end)->addDays($i * $interval);
 
-            $hasConflict = Event::where('location_id', $request->location_id)
+            $hasConflict = Event::where('location', $request->location)
                 ->where('start_time', '<', $currentEnd)
                 ->where('end_time', '>', $currentStart)
                 ->exists();
@@ -43,7 +43,7 @@ class EventService
 
             $event = Event::create([
                 'user_id' => $request->user()->id,
-                'location_id' => $request->location_id,
+                'location' => $request->location,
                 'department' => $request->department,
                 'campus' => $request->campus,
                 'title' => $request->title,

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use App\Models\Event;
 use App\Models\User;
-use App\Models\Location;
 use App\Models\Department;
 use App\Enums\Campus;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -24,7 +23,7 @@ class EventFactory extends Factory
 
         return [
             'user_id' => User::factory(),
-            'location_id' => Location::factory(),
+            'location' => $this->faker->city,
             'department' => Department::factory()->create()->name,
             'campus' => $this->faker->randomElement(array_column(Campus::cases(), 'value')),
             'title' => $this->faker->sentence,
@@ -41,20 +40,6 @@ class EventFactory extends Factory
             'floral_details' => [],
             'status' => 'pending',
         ];
-    }
-
-    public function configure()
-    {
-        return $this->afterMaking(function (Event $event) {
-            if ($event->location) {
-                $event->campus = $event->location->campus->value;
-            }
-        })->afterCreating(function (Event $event) {
-            if ($event->location) {
-                $event->campus = $event->location->campus->value;
-                $event->save();
-            }
-        });
     }
 }
 

--- a/database/migrations/2025_06_08_084740_create_events_table.php
+++ b/database/migrations/2025_06_08_084740_create_events_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
 
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
-            $table->foreignId('location_id')->constrained()->onDelete('cascade');
+            $table->string('location');
 
             $table->string('title');
             $table->text('details')->nullable();

--- a/database/migrations/2025_09_01_010000_add_department_campus_security_note_end_date_to_events_table.php
+++ b/database/migrations/2025_09_01_010000_add_department_campus_security_note_end_date_to_events_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
                 Campus::DAVISSON_STREET->value,
                 Campus::DALTON_ROAD->value,
                 Campus::SGC->value,
-            ])->after('location_id');
+            ])->after('location');
             $table->text('security_note')->nullable()->after('end_time');
         });
     }

--- a/resources/views/emails/event-approval.blade.php
+++ b/resources/views/emails/event-approval.blade.php
@@ -8,7 +8,7 @@
     <p>A new event has been created and requires your approval.</p>
     <ul>
         <li><strong>Title:</strong> {{ $event->title }}</li>
-        <li><strong>Location ID:</strong> {{ $event->location_id }}</li>
+        <li><strong>Location:</strong> {{ $event->location }}</li>
         <li><strong>Organizer:</strong> {{ $event->organizer_name }}</li>
         <li><strong>Organizer Email:</strong> {{ $event->organizer_email }}</li>
         <li><strong>Organizer Phone:</strong> {{ $event->organizer_phone }}</li>

--- a/tests/Feature/AdminBookingsRoleFilterTest.php
+++ b/tests/Feature/AdminBookingsRoleFilterTest.php
@@ -39,7 +39,7 @@ class AdminBookingsRoleFilterTest extends TestCase
 
         $photoEvent = Event::create([
             'user_id' => $owner->id,
-            'location_id' => $location->id,
+            'location' => $location->name,
             'department' => $department->name,
             'campus' => $location->campus->value,
             'title' => 'Photo Event',
@@ -54,7 +54,7 @@ class AdminBookingsRoleFilterTest extends TestCase
 
         $cateringEvent = Event::create([
             'user_id' => $owner->id,
-            'location_id' => $location->id,
+            'location' => $location->name,
             'department' => $department->name,
             'campus' => $location->campus->value,
             'title' => 'Catering Event',

--- a/tests/Feature/AdminEmailNotificationTest.php
+++ b/tests/Feature/AdminEmailNotificationTest.php
@@ -40,7 +40,7 @@ class AdminEmailNotificationTest extends TestCase
 
         $response = $this->actingAs($user)->postJson('/api/events', [
             'title' => 'Email Test',
-            'location_id' => $location->id,
+            'location' => $location->name,
             'start_time' => now()->addDays(15)->toDateTimeString(),
             'end_time' => now()->addDays(16)->toDateTimeString(),
             'expected_attendance' => 20,

--- a/tests/Feature/EventAdditionalDetailsTest.php
+++ b/tests/Feature/EventAdditionalDetailsTest.php
@@ -35,7 +35,7 @@ class EventAdditionalDetailsTest extends TestCase
 
         $payload = [
             'title' => 'Test Event',
-            'location_id' => $location->id,
+            'location' => $location->name,
             'department' => $department->name,
             'campus' => $location->campus->value,
             'start_time' => $start->toDateTimeString(),
@@ -82,7 +82,7 @@ class EventAdditionalDetailsTest extends TestCase
         $end = (clone $start)->addHours(2);
 
         $event = Event::factory()->for($user)->create([
-            'location_id' => $location->id,
+            'location' => $location->name,
             'department' => $department->name,
             'campus' => $location->campus->value,
             'start_time' => $start,

--- a/tests/Feature/EventLeadTimeTest.php
+++ b/tests/Feature/EventLeadTimeTest.php
@@ -34,7 +34,7 @@ class EventLeadTimeTest extends TestCase
 
         $response = $this->actingAs($user)->postJson('/api/events', [
             'title' => 'Test Event',
-            'location_id' => $location->id,
+            'location' => $location->name,
             'start_time' => now()->addDays(10)->toDateTimeString(),
             'end_time' => now()->addDays(11)->toDateTimeString(),
             'department' => $department->name,
@@ -55,7 +55,7 @@ class EventLeadTimeTest extends TestCase
 
         $response = $this->actingAs($user)->postJson('/api/events', [
             'title' => 'Allowed Event',
-            'location_id' => $location->id,
+            'location' => $location->name,
             'start_time' => now()->addDays(15)->toDateTimeString(),
             'end_time' => now()->addDays(16)->toDateTimeString(),
             'department' => $department->name,

--- a/tests/Feature/PhotographyTypeTest.php
+++ b/tests/Feature/PhotographyTypeTest.php
@@ -48,7 +48,7 @@ class PhotographyTypeTest extends TestCase
 
         $response = $this->actingAs($user)->postJson('/api/events', [
             'title' => 'Test',
-            'location_id' => $location->id,
+            'location' => $location->name,
             'start_time' => now()->addDay()->toDateTimeString(),
             'end_time' => now()->addDays(2)->toDateTimeString(),
             'department' => $department->name,

--- a/tests/Feature/SecurityServiceTest.php
+++ b/tests/Feature/SecurityServiceTest.php
@@ -34,7 +34,7 @@ class SecurityServiceTest extends TestCase
 
         $response = $this->actingAs($user)->postJson('/api/events', [
             'title' => 'Security Event',
-            'location_id' => $location->id,
+            'location' => $location->name,
             'start_time' => now()->addDay()->toDateTimeString(),
             'end_time' => now()->addDays(2)->toDateTimeString(),
             'department' => $department->name,


### PR DESCRIPTION
## Summary
- Replace `location_id` foreign key with plain `location` text on events
- Validate and check scheduling conflicts using location names
- Update API requests, services, and tests to work with text locations

## Testing
- `composer install --ignore-platform-reqs -n` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b2fb959a7c8333af2f9195f0b3be92